### PR TITLE
複数ロールのタスクを install/link に分割し shared filetree linker を改善

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -22,26 +22,36 @@
       tags:
         - zsh
         - minimum
+        - install
+        - link
 
     - role: fzf
       tags:
         - fzf
         - normal
+        - install
+        - link
 
     - role: tmux
       tags:
         - tmux
         - minimum
+        - install
+        - link
 
     - role: vim
       tags:
         - vim
         - minimum
+        - install
+        - link
 
     - role: neovim
       tags:
         - neovim
         - normal
+        - install
+        - link
 
     - role: C
       tags:
@@ -57,14 +67,19 @@
       tags:
         - mise
         - normal
+        - install
+        - link
 
 
     - role: uv
       tags:
         - python
         - extra
+        - install
+        - link
 
     - role: go
       tags:
         - go
         - extra
+        - install

--- a/roles/fzf/tasks/install.yml
+++ b/roles/fzf/tasks/install.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Clone fzf (Linux)
+  ansible.builtin.git:
+    repo: https://github.com/junegunn/fzf.git
+    dest: "{{ home }}/.fzf"
+    version: master
+  when: ansible_facts['system'] == 'Linux'
+
+- name: Install & Update fzf (Linux)
+  ansible.builtin.shell: $HOME/.fzf/install --no-key-bindings --no-completion --no-update-rc --no-bash --no-zsh --no-fish
+  when: ansible_facts['system'] == 'Linux'
+
+- name: Install fzf (macOS)
+  community.general.homebrew:
+    name: fzf
+    state: latest
+  when: ansible_facts['system'] == 'Darwin'

--- a/roles/fzf/tasks/link.yml
+++ b/roles/fzf/tasks/link.yml
@@ -1,6 +1,6 @@
 ---
 
 - name: Link fzf config tree
-  ansible.builtin.include_tasks: ../../shared/tasks/link_filetree.yml
+  ansible.builtin.import_tasks: ../../shared/tasks/link_filetree.yml
   vars:
     _filetree_root: "{{ role_path }}/files/"

--- a/roles/fzf/tasks/link.yml
+++ b/roles/fzf/tasks/link.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Link fzf config tree
+  ansible.builtin.include_tasks: ../../shared/tasks/link_filetree.yml
+  vars:
+    _filetree_root: "{{ role_path }}/files/"

--- a/roles/fzf/tasks/main.yml
+++ b/roles/fzf/tasks/main.yml
@@ -1,35 +1,11 @@
 ---
 
-- name: Clone fzf (Linux)
-  ansible.builtin.git:
-    repo: https://github.com/junegunn/fzf.git
-    dest: "{{ home }}/.fzf"
-    version: master
-  when: ansible_facts['system'] == 'Linux'
+- name: fzf | install
+  ansible.builtin.import_tasks: install.yml
+  tags:
+    - install
 
-- name: Install & Update fzf (Linux)
-  ansible.builtin.shell: $HOME/.fzf/install --no-key-bindings --no-completion --no-update-rc --no-bash --no-zsh --no-fish
-  when: ansible_facts['system'] == 'Linux'
-
-- name: Install fzf (macOS)
-  community.general.homebrew:
-    name: fzf
-    state: latest
-  when: ansible_facts['system'] == 'Darwin'
-
-- name: Ensure fzf config directories exist
-  ansible.builtin.file:
-    path: "{{ home }}/{{ item.path }}"
-    state: directory
-    mode: "0755"
-  with_community.general.filetree: "{{ role_path }}/files/"
-  when: item.state == 'directory'
-
-- name: Link fzf configuration files
-  ansible.builtin.file:
-    src: "{{ item.src }}"
-    dest: "{{ home }}/{{ item.path }}"
-    state: link
-    force: true
-  with_community.general.filetree: "{{ role_path }}/files/"
-  when: item.state == 'file'
+- name: fzf | link
+  ansible.builtin.import_tasks: link.yml
+  tags:
+    - link

--- a/roles/mise/tasks/install.yml
+++ b/roles/mise/tasks/install.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Check if mise is installed
+  ansible.builtin.shell: "command -v mise"
+  register: mise_exists
+  ignore_errors: true
+
+- name: Install mise
+  when: mise_exists is failed
+  ansible.builtin.shell: "curl https://mise.run | sh"
+
+- name: Update mise
+  ansible.builtin.shell: "mise self-update"

--- a/roles/mise/tasks/link.yml
+++ b/roles/mise/tasks/link.yml
@@ -1,6 +1,6 @@
 ---
 
 - name: Link mise config tree
-  ansible.builtin.include_tasks: ../../shared/tasks/link_filetree.yml
+  ansible.builtin.import_tasks: ../../shared/tasks/link_filetree.yml
   vars:
     _filetree_root: "{{ role_path }}/files/"

--- a/roles/mise/tasks/link.yml
+++ b/roles/mise/tasks/link.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Link mise config tree
+  ansible.builtin.include_tasks: ../../shared/tasks/link_filetree.yml
+  vars:
+    _filetree_root: "{{ role_path }}/files/"

--- a/roles/mise/tasks/main.yml
+++ b/roles/mise/tasks/main.yml
@@ -1,30 +1,11 @@
 ---
 
-- name: Check if mise is installed
-  ansible.builtin.shell: "command -v mise"
-  register: mise_exists
-  ignore_errors: true
+- name: mise | install
+  ansible.builtin.import_tasks: install.yml
+  tags:
+    - install
 
-- name: Install mise
-  when: mise_exists is failed
-  ansible.builtin.shell: "curl https://mise.run | sh"
-
-- name: Update mise
-  ansible.builtin.shell: "mise self-update"
-
-- name: Ensure mise config directories exist
-  ansible.builtin.file:
-    path: "{{ home }}/{{ item.path }}"
-    state: directory
-    mode: "0755"
-  with_community.general.filetree: "{{ role_path }}/files/"
-  when: item.state == 'directory'
-
-- name: Link mise configuration files
-  ansible.builtin.file:
-    src: "{{ item.src }}"
-    dest: "{{ home }}/{{ item.path }}"
-    state: link
-    force: true
-  with_community.general.filetree: "{{ role_path }}/files/"
-  when: item.state == 'file'
+- name: mise | link
+  ansible.builtin.import_tasks: link.yml
+  tags:
+    - link

--- a/roles/neovim/tasks/install.yml
+++ b/roles/neovim/tasks/install.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Install neovim
+  become: true
+  ansible.builtin.package:
+    name: neovim
+    state: latest

--- a/roles/neovim/tasks/link.yml
+++ b/roles/neovim/tasks/link.yml
@@ -1,6 +1,6 @@
 ---
 
 - name: Link neovim config tree
-  ansible.builtin.include_tasks: ../../shared/tasks/link_filetree.yml
+  ansible.builtin.import_tasks: ../../shared/tasks/link_filetree.yml
   vars:
     _filetree_root: "{{ role_path }}/files/"

--- a/roles/neovim/tasks/link.yml
+++ b/roles/neovim/tasks/link.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Link neovim config tree
+  ansible.builtin.include_tasks: ../../shared/tasks/link_filetree.yml
+  vars:
+    _filetree_root: "{{ role_path }}/files/"

--- a/roles/neovim/tasks/main.yml
+++ b/roles/neovim/tasks/main.yml
@@ -1,24 +1,11 @@
 ---
 
-- name: Install neovim
-  become: true
-  ansible.builtin.package:
-    name: neovim
-    state: latest
+- name: neovim | install
+  ansible.builtin.import_tasks: install.yml
+  tags:
+    - install
 
-- name: Ensure neovim config directories exist
-  ansible.builtin.file:
-    path: "{{ home }}/{{ item.path }}"
-    state: directory
-    mode: "0755"
-  with_community.general.filetree: "{{ role_path }}/files/"
-  when: item.state == 'directory'
-
-- name: Link neovim configuration files
-  ansible.builtin.file:
-    src: "{{ item.src }}"
-    dest: "{{ home }}/{{ item.path }}"
-    state: link
-    force: true
-  with_community.general.filetree: "{{ role_path }}/files/"
-  when: item.state == 'file'
+- name: neovim | link
+  ansible.builtin.import_tasks: link.yml
+  tags:
+    - link

--- a/roles/shared/tasks/link_filetree.yml
+++ b/roles/shared/tasks/link_filetree.yml
@@ -1,0 +1,23 @@
+---
+# Required:
+# - _filetree_root: path to role files root (e.g. "{{ role_path }}/files/")
+# Optional:
+# - _dir_mode: directory mode (default "0755")
+# - _link_force: force symlink overwrite (default true)
+
+- name: Ensure config directories exist
+  ansible.builtin.file:
+    path: "{{ home }}/{{ item.path }}"
+    state: directory
+    mode: "{{ _dir_mode | default('0755') }}"
+  with_community.general.filetree: "{{ _filetree_root }}"
+  when: item.state == 'directory'
+
+- name: Link configuration files
+  ansible.builtin.file:
+    src: "{{ item.src }}"
+    dest: "{{ home }}/{{ item.path }}"
+    state: link
+    force: "{{ _link_force | default(true) }}"
+  with_community.general.filetree: "{{ _filetree_root }}"
+  when: item.state == 'file'

--- a/roles/shared/tasks/link_filetree.yml
+++ b/roles/shared/tasks/link_filetree.yml
@@ -5,12 +5,16 @@
 # - _dir_mode: directory mode (default "0755")
 # - _link_force: force symlink overwrite (default true)
 
+- name: Collect config tree entries
+  ansible.builtin.set_fact:
+    _filetree_items: "{{ lookup('community.general.filetree', _filetree_root, wantlist=True) }}"
+
 - name: Ensure config directories exist
   ansible.builtin.file:
     path: "{{ home }}/{{ item.path }}"
     state: directory
     mode: "{{ _dir_mode | default('0755') }}"
-  with_community.general.filetree: "{{ _filetree_root }}"
+  loop: "{{ _filetree_items }}"
   when: item.state == 'directory'
 
 - name: Link configuration files
@@ -19,5 +23,5 @@
     dest: "{{ home }}/{{ item.path }}"
     state: link
     force: "{{ _link_force | default(true) }}"
-  with_community.general.filetree: "{{ _filetree_root }}"
+  loop: "{{ _filetree_items }}"
   when: item.state == 'file'

--- a/roles/tmux/tasks/install.yml
+++ b/roles/tmux/tasks/install.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Install tmux
+  become: true
+  ansible.builtin.package:
+    name: tmux
+    state: latest
+
+- name: Clone tpm
+  ansible.builtin.git:
+    repo: https://github.com/tmux-plugins/tpm
+    dest: "{{ home }}/.tmux/plugins/tpm"
+    version: master

--- a/roles/tmux/tasks/link.yml
+++ b/roles/tmux/tasks/link.yml
@@ -1,6 +1,6 @@
 ---
 
 - name: Link tmux config tree
-  ansible.builtin.include_tasks: ../../shared/tasks/link_filetree.yml
+  ansible.builtin.import_tasks: ../../shared/tasks/link_filetree.yml
   vars:
     _filetree_root: "{{ role_path }}/files/"

--- a/roles/tmux/tasks/link.yml
+++ b/roles/tmux/tasks/link.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Link tmux config tree
+  ansible.builtin.include_tasks: ../../shared/tasks/link_filetree.yml
+  vars:
+    _filetree_root: "{{ role_path }}/files/"

--- a/roles/tmux/tasks/main.yml
+++ b/roles/tmux/tasks/main.yml
@@ -1,30 +1,11 @@
 ---
 
-- name: Install tmux
-  become: true
-  ansible.builtin.package:
-    name: tmux
-    state: latest
+- name: tmux | install
+  ansible.builtin.import_tasks: install.yml
+  tags:
+    - install
 
-- name: Ensure tmux directories exist
-  ansible.builtin.file:
-    path: "{{ home }}/{{ item.path }}"
-    state: directory
-    mode: "0755"
-  with_community.general.filetree: "{{ role_path }}/files/"
-  when: item.state == 'directory'
-
-- name: Clone tpm
-  ansible.builtin.git:
-    repo: https://github.com/tmux-plugins/tpm
-    dest: "{{ home }}/.tmux/plugins/tpm"
-    version: master
-
-- name: Link tmux configuration files
-  ansible.builtin.file:
-    src: "{{ item.src }}"
-    dest: "{{ home }}/{{ item.path }}"
-    state: link
-    force: true
-  with_community.general.filetree: "{{ role_path }}/files/"
-  when: item.state == 'file'
+- name: tmux | link
+  ansible.builtin.import_tasks: link.yml
+  tags:
+    - link

--- a/roles/uv/tasks/install.yml
+++ b/roles/uv/tasks/install.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Check if uv is installed
+  ansible.builtin.shell: command -v uv
+  register: uv_exists
+  ignore_errors: true
+
+- name: Install uv
+  when: uv_exists is failed
+  ansible.builtin.shell: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+- name: Update uv
+  ansible.builtin.shell: "uv self update"

--- a/roles/uv/tasks/link.yml
+++ b/roles/uv/tasks/link.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Link uv config tree
+  ansible.builtin.include_tasks: ../../shared/tasks/link_filetree.yml
+  vars:
+    _filetree_root: "{{ role_path }}/files/"

--- a/roles/uv/tasks/link.yml
+++ b/roles/uv/tasks/link.yml
@@ -1,6 +1,6 @@
 ---
 
 - name: Link uv config tree
-  ansible.builtin.include_tasks: ../../shared/tasks/link_filetree.yml
+  ansible.builtin.import_tasks: ../../shared/tasks/link_filetree.yml
   vars:
     _filetree_root: "{{ role_path }}/files/"

--- a/roles/uv/tasks/main.yml
+++ b/roles/uv/tasks/main.yml
@@ -1,30 +1,11 @@
 ---
 
-- name: Check if uv is installed
-  ansible.builtin.shell: command -v uv
-  register: uv_exists
-  ignore_errors: true
+- name: uv | install
+  ansible.builtin.import_tasks: install.yml
+  tags:
+    - install
 
-- name: Install uv
-  when: uv_exists is failed
-  ansible.builtin.shell: curl -LsSf https://astral.sh/uv/install.sh | sh
-
-- name: Update uv
-  ansible.builtin.shell: "uv self update"
-
-- name: Ensure uv config directories exist
-  ansible.builtin.file:
-    path: "{{ home }}/{{ item.path }}"
-    state: directory
-    mode: "0755"
-  with_community.general.filetree: "{{ role_path }}/files/"
-  when: item.state == 'directory'
-
-- name: Link uv configuration files
-  ansible.builtin.file:
-    src: "{{ item.src }}"
-    dest: "{{ home }}/{{ item.path }}"
-    state: link
-    force: true
-  with_community.general.filetree: "{{ role_path }}/files/"
-  when: item.state == 'file'
+- name: uv | link
+  ansible.builtin.import_tasks: link.yml
+  tags:
+    - link

--- a/roles/vim/tasks/install.yml
+++ b/roles/vim/tasks/install.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Install vim
+  become: true
+  ansible.builtin.package:
+    name: vim
+    state: latest

--- a/roles/vim/tasks/link.yml
+++ b/roles/vim/tasks/link.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Link vim config tree
+  ansible.builtin.include_tasks: ../../shared/tasks/link_filetree.yml
+  vars:
+    _filetree_root: "{{ role_path }}/files/"

--- a/roles/vim/tasks/link.yml
+++ b/roles/vim/tasks/link.yml
@@ -1,6 +1,6 @@
 ---
 
 - name: Link vim config tree
-  ansible.builtin.include_tasks: ../../shared/tasks/link_filetree.yml
+  ansible.builtin.import_tasks: ../../shared/tasks/link_filetree.yml
   vars:
     _filetree_root: "{{ role_path }}/files/"

--- a/roles/vim/tasks/main.yml
+++ b/roles/vim/tasks/main.yml
@@ -1,24 +1,11 @@
 ---
 
-- name: Install vim
-  become: true
-  ansible.builtin.package:
-    name: vim
-    state: latest
+- name: vim | install
+  ansible.builtin.import_tasks: install.yml
+  tags:
+    - install
 
-- name: Ensure vim directories exist
-  ansible.builtin.file:
-    path: "{{ home }}/{{ item.path }}"
-    state: directory
-    mode: "0755"
-  with_community.general.filetree: "{{ role_path }}/files/"
-  when: item.state == 'directory'
-
-- name: Link vim configuration files
-  ansible.builtin.file:
-    src: "{{ item.src }}"
-    dest: "{{ home }}/{{ item.path }}"
-    state: link
-    force: true
-  with_community.general.filetree: "{{ role_path }}/files/"
-  when: item.state == 'file'
+- name: vim | link
+  ansible.builtin.import_tasks: link.yml
+  tags:
+    - link

--- a/roles/zsh/tasks/install.yml
+++ b/roles/zsh/tasks/install.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Install zsh (Linux)
+  become: true
+  ansible.builtin.package:
+    name: zsh
+    state: latest
+  when: ansible_facts['system'] == 'Linux'
+
+- name: Install zsh (macOS)
+  community.general.homebrew:
+    name: zsh
+    state: latest
+  when: ansible_facts['system'] == 'Darwin'

--- a/roles/zsh/tasks/link.yml
+++ b/roles/zsh/tasks/link.yml
@@ -1,6 +1,6 @@
 ---
 
 - name: Link zsh config tree
-  ansible.builtin.include_tasks: ../../shared/tasks/link_filetree.yml
+  ansible.builtin.import_tasks: ../../shared/tasks/link_filetree.yml
   vars:
     _filetree_root: "{{ role_path }}/files/"

--- a/roles/zsh/tasks/link.yml
+++ b/roles/zsh/tasks/link.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Link zsh config tree
+  ansible.builtin.include_tasks: ../../shared/tasks/link_filetree.yml
+  vars:
+    _filetree_root: "{{ role_path }}/files/"

--- a/roles/zsh/tasks/main.yml
+++ b/roles/zsh/tasks/main.yml
@@ -1,31 +1,11 @@
 ---
 
-- name: Install zsh (Linux)
-  become: true
-  ansible.builtin.package:
-    name: zsh
-    state: latest
-  when: ansible_facts['system'] == 'Linux'
+- name: zsh | install
+  ansible.builtin.import_tasks: install.yml
+  tags:
+    - install
 
-- name: Install zsh (macOS)
-  community.general.homebrew:
-    name: zsh
-    state: latest
-  when: ansible_facts['system'] == 'Darwin'
-
-- name: Ensure zsh directories exist
-  ansible.builtin.file:
-    path: "{{ home }}/{{ item.path }}"
-    state: directory
-    mode: "0755"
-  with_community.general.filetree: "{{ role_path }}/files/"
-  when: item.state == 'directory'
-
-- name: Link zsh configuration files
-  ansible.builtin.file:
-    src: "{{ item.src }}"
-    dest: "{{ home }}/{{ item.path }}"
-    state: link
-    force: true
-  with_community.general.filetree: "{{ role_path }}/files/"
-  when: item.state == 'file'
+- name: zsh | link
+  ansible.builtin.import_tasks: link.yml
+  tags:
+    - link


### PR DESCRIPTION
### 背景

- 複数ロールで混在していたインストール処理と設定ファイルのリンク処理を整理し、共通化できるリンク処理を shared task に集約したかったためです。

### 変更内容

- `fzf`、`mise`、`neovim`、`tmux`、`uv`、`vim`、`zsh` の各ロールでタスクを `install.yml` と `link.yml` に分割しました。
- 各ロールの `tasks/main.yml` から `install` / `link` タグ付きで読み込む構成に整理しました。
- `roles/shared/tasks/link_filetree.yml` を追加し、設定ディレクトリの作成とシンボリックリンク作成を共通化しました。
- 各ロールの `link.yml` から shared task を利用するようにして、`_filetree_root: "{{ role_path }}/files/"` を渡す構成にしました。
- レビュー対応として、shared task の読み込みを `include_tasks` から `import_tasks` に変更し、タグ付き実行でもリンク作成タスクが正しく実行されるようにしました。
- あわせて `community.general.filetree` の結果を一度だけ取得して使い回すようにし、同じツリーを二重に走査しないようにしました。

### 確認内容

- `ansible-playbook -i ./inventories/production/hosts.yml ./playbook.yml --syntax-check --tags zsh`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d12eedcffc8324b251c76c3ee50f1a)
