### PR TITLE
install role の shell 依存を減らす

### DIFF
--- a/roles/go/tasks/main.yml
+++ b/roles/go/tasks/main.yml
@@ -1,17 +1,28 @@
 ---
 
 - name: Check if go {{ go_version }} is installed
-  ansible.builtin.shell:
-    "mise list golang | grep {{ go_version }}"
-  register: go_exists
-  ignore_errors: true
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - where
+      - "go@{{ go_version }}"
+  register: go_installation
+  changed_when: false
+  failed_when: false
 
 - name: Install go {{ go_version }}
-  when: go_exists is failed
-  ansible.builtin.shell:
-    "mise install go@{{ go_version }}"
+  when: go_installation.rc != 0
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - install
+      - "go@{{ go_version }}"
 
 - name: Set global version
-  when: go_exists is failed
-  ansible.builtin.shell:
-    "mise use -g go@{{ go_version }}"
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - use
+      - -g
+      - "go@{{ go_version }}"
+  changed_when: go_installation.rc != 0

--- a/roles/go/tasks/main.yml
+++ b/roles/go/tasks/main.yml
@@ -19,10 +19,10 @@
       - "go@{{ go_version }}"
 
 - name: Set global version
+  when: go_installation.rc != 0
   ansible.builtin.command:
     argv:
       - "{{ home }}/.local/bin/mise"
       - use
       - -g
       - "go@{{ go_version }}"
-  changed_when: go_installation.rc != 0

--- a/roles/mise/tasks/install.yml
+++ b/roles/mise/tasks/install.yml
@@ -1,13 +1,20 @@
 ---
 
-- name: Check if mise is installed
-  ansible.builtin.shell: "command -v mise"
-  register: mise_exists
-  ignore_errors: true
+- name: Check if mise binary exists
+  ansible.builtin.stat:
+    path: "{{ home }}/.local/bin/mise"
+  register: mise_binary
 
 - name: Install mise
-  when: mise_exists is failed
-  ansible.builtin.shell: "curl https://mise.run | sh"
+  when: not mise_binary.stat.exists
+  ansible.builtin.shell: curl https://mise.run | sh
+  args:
+    creates: "{{ home }}/.local/bin/mise"
 
 - name: Update mise
-  ansible.builtin.shell: "mise self-update"
+  when: mise_binary.stat.exists
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - self-update
+  changed_when: false

--- a/roles/mise/tasks/install.yml
+++ b/roles/mise/tasks/install.yml
@@ -1,20 +1,22 @@
 ---
 
-- name: Check if mise binary exists
+- name: Check if mise is installed
   ansible.builtin.stat:
     path: "{{ home }}/.local/bin/mise"
   register: mise_binary
 
+- name: Download mise installer
+  when: not mise_binary.stat.exists
+  ansible.builtin.get_url:
+    url: https://mise.run
+    dest: /tmp/mise-install.sh
+    mode: "0755"
+    force: true
+
 - name: Install mise
   when: not mise_binary.stat.exists
-  ansible.builtin.shell: curl https://mise.run | sh
-  args:
-    creates: "{{ home }}/.local/bin/mise"
-
-- name: Update mise
-  when: mise_binary.stat.exists
   ansible.builtin.command:
     argv:
-      - "{{ home }}/.local/bin/mise"
-      - self-update
-  changed_when: false
+      - /tmp/mise-install.sh
+  args:
+    creates: "{{ home }}/.local/bin/mise"

--- a/roles/rust/tasks/main.yml
+++ b/roles/rust/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 
-- name: Check if cargo is installed
-  ansible.builtin.shell: command -v cargo
-  register: cargo_exists
-  ignore_errors: true
+- name: Check if cargo binary exists
+  ansible.builtin.stat:
+    path: "{{ home }}/.cargo/bin/cargo"
+  register: cargo_binary
 
 - name: Download Rust installer
-  when: cargo_exists is failed
+  when: not cargo_binary.stat.exists
   ansible.builtin.get_url:
     url: https://sh.rustup.rs
     dest: /tmp/sh.rustup.rs
@@ -14,20 +14,25 @@
     force: true
 
 - name: Install Rust
-  when: cargo_exists is failed
-  ansible.builtin.shell: /tmp/sh.rustup.rs -y
-
-- name: Activate Rust
-  when: cargo_exists is failed
-  ansible.builtin.shell: export PATH="$HOME/.cargo/bin:$PATH"
+  when: not cargo_binary.stat.exists
+  ansible.builtin.command:
+    argv:
+      - /tmp/sh.rustup.rs
+      - -y
 
 - name: Update Rust
-  when: cargo_exists is success
-  ansible.builtin.shell: rustup update
+  when: cargo_binary.stat.exists
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.cargo/bin/rustup"
+      - update
+  changed_when: false
 
 - name: Install "cargo-update"
   community.general.cargo:
     name: cargo-update
+  environment:
+    PATH: "{{ home }}/.cargo/bin:{{ ansible_env.PATH }}"
   ignore_errors: true
 
 - name: Link rust config

--- a/roles/rust/tasks/main.yml
+++ b/roles/rust/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Check if cargo binary exists
+- name: Check if cargo is installed
   ansible.builtin.stat:
     path: "{{ home }}/.cargo/bin/cargo"
   register: cargo_binary
@@ -19,6 +19,8 @@
     argv:
       - /tmp/sh.rustup.rs
       - -y
+  args:
+    creates: "{{ home }}/.cargo/bin/cargo"
 
 - name: Update Rust
   when: cargo_binary.stat.exists
@@ -26,13 +28,12 @@
     argv:
       - "{{ home }}/.cargo/bin/rustup"
       - update
-  changed_when: false
 
 - name: Install "cargo-update"
   community.general.cargo:
     name: cargo-update
   environment:
-    PATH: "{{ home }}/.cargo/bin:{{ ansible_env.PATH }}"
+    PATH: "{{ home }}/.cargo/bin:{{ ansible_facts['env']['PATH'] }}"
   ignore_errors: true
 
 - name: Link rust config

--- a/roles/uv/tasks/install.yml
+++ b/roles/uv/tasks/install.yml
@@ -1,13 +1,21 @@
 ---
 
-- name: Check if uv is installed
-  ansible.builtin.shell: command -v uv
-  register: uv_exists
-  ignore_errors: true
+- name: Check if uv binary exists
+  ansible.builtin.stat:
+    path: "{{ home }}/.local/bin/uv"
+  register: uv_binary
 
 - name: Install uv
-  when: uv_exists is failed
+  when: not uv_binary.stat.exists
   ansible.builtin.shell: curl -LsSf https://astral.sh/uv/install.sh | sh
+  args:
+    creates: "{{ home }}/.local/bin/uv"
 
 - name: Update uv
-  ansible.builtin.shell: "uv self update"
+  when: uv_binary.stat.exists
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/uv"
+      - self
+      - update
+  changed_when: false

--- a/roles/uv/tasks/install.yml
+++ b/roles/uv/tasks/install.yml
@@ -1,13 +1,23 @@
 ---
 
-- name: Check if uv binary exists
+- name: Check if uv is installed
   ansible.builtin.stat:
     path: "{{ home }}/.local/bin/uv"
   register: uv_binary
 
+- name: Download uv installer
+  when: not uv_binary.stat.exists
+  ansible.builtin.get_url:
+    url: https://astral.sh/uv/install.sh
+    dest: /tmp/uv-install.sh
+    mode: "0755"
+    force: true
+
 - name: Install uv
   when: not uv_binary.stat.exists
-  ansible.builtin.shell: curl -LsSf https://astral.sh/uv/install.sh | sh
+  ansible.builtin.command:
+    argv:
+      - /tmp/uv-install.sh
   args:
     creates: "{{ home }}/.local/bin/uv"
 
@@ -18,4 +28,3 @@
       - "{{ home }}/.local/bin/uv"
       - self
       - update
-  changed_when: false


### PR DESCRIPTION
## 概要
- install 系 role のうち `mise` / `uv` / `rust` で shell 依存を減らしました
- issue #153 の続きとして、冪等性と読みやすさを改善しました

## 変更内容
- `roles/mise/tasks/install.yml`
  - `stat` で mise バイナリの有無を確認
  - `get_url` と `command` でインストーラ実行に変更
- `roles/uv/tasks/install.yml`
  - `stat` で uv バイナリの有無を確認
  - `get_url` と `command` でインストーラ実行に変更
  - update もフルパスの `command` に変更
- `roles/rust/tasks/main.yml`
  - `stat` で cargo バイナリの有無を確認
  - rustup インストーラ実行を `command` に変更
  - 効果の残らない `export PATH` task を削除
  - cargo module 実行時だけ PATH を渡すよう整理

## 意図
- shell を使わなくてもよい箇所を減らし、role ごとの挙動を YAML から追いやすくするためです
- 再実行時の判定をより明示的にするためです

## 確認
- `ansible-playbook --syntax-check -i inventories/production playbook.yml`

## 関連
- Closes #153
