### PR TITLE
git role を追加し ghq と gitignore を整理する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-.ssh/
-.aws/
-.azure/
-.zsh/zsh_functions/
-.zsh/zsh-history
-.zsh/.zcompdump
-
-fonts/
+# Repository-specific ignores
+.codex
+.serena

--- a/playbook.yml
+++ b/playbook.yml
@@ -8,6 +8,11 @@
         - common
         - minimum
 
+    - role: git
+      tags:
+        - git
+        - minimum
+
     - role: cli_tools
       tags:
         - cli_tools

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -16,10 +16,3 @@
       - snapd
       - "{{ 'libssl-dev' if ansible_pkg_mgr == 'apt' else 'openssl-devel' }}"
     state: latest
-
-- name: Link .gitconfig
-  ansible.builtin.file:
-    src: "{{ role_path }}/files/.gitconfig"
-    dest: "{{ home }}/.gitconfig"
-    state: link
-    force: true

--- a/roles/git/files/.gitconfig
+++ b/roles/git/files/.gitconfig
@@ -1,6 +1,3 @@
-[user]
-	email = K.Sakurai2000@gmail.com
-	name = Sakurai
 [core]
 	autocrlf = false
 	editor = vim
@@ -19,10 +16,19 @@
 	sort = -committerdate
 [commit]
 	verbose = true
+	gpgsign = true
 [push]
 	default = simple
 	autoSetupRemote = true
 	followTags = true
+[merge]
+    ff = false
+[fetch]
+    prune = true
+	pruneTags = true
+	all = true
+[pull]
+	ff = only
 [rebase]
     autosquash = true  # fixup/squash を自動適用
     autostash  = true  # rebase前後に stash/pop を自動実行
@@ -30,12 +36,6 @@
 [rerere]
 	enabled = true
 	autoupdate = true
-[pull]
-	ff = only
-[fetch]
-    prune = true
-	pruneTags = true
-	all = true
 [diff]
 	algorithm = histogram
 	colorMoved = plain
@@ -69,3 +69,17 @@
 # 	diff-so-fancy=true
 
 # https://blog.gitbutler.com/how-git-core-devs-configure-git/
+
+[gpg]
+	format = ssh
+[credential "https://github.com"]
+	helper =
+	helper = !/usr/bin/gh auth git-credential
+[credential "https://gist.github.com"]
+	helper =
+	helper = !/usr/bin/gh auth git-credential
+
+[include]
+	path = .gitconfig.local
+[ghq]
+	root = ~/projects

--- a/roles/git/files/.gitconfig.local
+++ b/roles/git/files/.gitconfig.local
@@ -1,0 +1,12 @@
+# Local git configuration
+# This file is included by .gitconfig via [include] path.
+# Copy this structure into your local ~/.gitconfig.local and replace the values
+# with your own settings as needed.
+
+[user]
+	email = your-email@example.com
+	name = Your Name
+	signingKey = key::your-signing-key
+
+# [commit]
+#	gpgsign = false

--- a/roles/git/files/.gitignore
+++ b/roles/git/files/.gitignore
@@ -1,0 +1,4 @@
+# Personal and sensitive data (deployment target)
+.ssh/
+.aws/
+.azure/

--- a/roles/git/meta/main.yml
+++ b/roles/git/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: mise

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -1,0 +1,54 @@
+---
+- name: Install git
+  become: yes
+  ansible.builtin.package:
+    name: git
+    state: present
+
+- name: Check if ghq is installed via mise
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - where
+      - ghq
+  register: ghq_installation
+  changed_when: false
+  failed_when: false
+
+- name: Install ghq via mise
+  when: ghq_installation.rc != 0
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - install
+      - ghq
+
+- name: Set ghq via mise
+  when: ghq_installation.rc != 0
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - use
+      - -g
+      - ghq
+
+- name: Link .gitconfig
+  ansible.builtin.file:
+    src: "{{ role_path }}/files/.gitconfig"
+    dest: "{{ home }}/.gitconfig"
+    state: link
+    force: yes
+
+- name: Link .gitconfig.local template
+  ansible.builtin.file:
+    src: "{{ role_path }}/files/.gitconfig.local"
+    dest: "{{ home }}/.gitconfig.local"
+    state: link
+    force: no
+
+- name: Link .gitignore to home directory
+  ansible.builtin.file:
+    src: "{{ role_path }}/files/.gitignore"
+    dest: "{{ home }}/.gitignore"
+    state: link
+    force: yes


### PR DESCRIPTION
## 概要
- `git` 関連の設定と導入処理を `common` role から切り出し、専用の `git` role を追加しました
- `ghq` の導入を `mise` ベースに整理しました
- リポジトリ管理用の `.gitignore` と、ホームディレクトリへ配布する `.gitignore` を分離しました

## 変更内容
- `roles/git/` を追加
  - `.gitconfig`
  - `.gitconfig.local` のテンプレート
  - ホームディレクトリ配布用 `.gitignore`
  - `ghq` 導入を含む task / meta
- `roles/common/tasks/main.yml`
  - `.gitconfig` のリンク処理を削除
- `playbook.yml`
  - `git` role を追加
- リポジトリ直下の `.gitignore`
  - リポジトリ管理に必要な内容へ整理

## ghq について
- `ghq` は `go install` ではなく `mise install ghq` / `mise use -g ghq` で導入する形に変更しました
- `git` role の依存は `go` ではなく `mise` にしています
- `.gitconfig` には `ghq.root = ~/projects` を追加しています

## 意図
- Git 関連の責務を `common` role から切り出して見通しを良くするためです
- `ghq` の導入を Go のインストール先に依存させず、`mise` 管理のツールとして扱えるようにするためです
- リポジトリ自身の無視設定と、ホームディレクトリへ展開する無視設定を分けて管理しやすくするためです

## 確認
- `ansible-playbook --syntax-check -i inventories/production playbook.yml`
