### PR TITLE
mise と go のセットアップ責務を簡素化する

### DIFF
--- a/roles/go/tasks/main.yml
+++ b/roles/go/tasks/main.yml
@@ -6,23 +6,14 @@
       - "{{ home }}/.local/bin/mise"
       - where
       - "go@{{ go_version }}"
-  register: go_installation
+  register: go_exists
   changed_when: false
   failed_when: false
 
 - name: Install go {{ go_version }}
-  when: go_installation.rc != 0
+  when: go_exists.rc != 0
   ansible.builtin.command:
     argv:
       - "{{ home }}/.local/bin/mise"
       - install
-      - "go@{{ go_version }}"
-
-- name: Set global version
-  when: go_installation.rc != 0
-  ansible.builtin.command:
-    argv:
-      - "{{ home }}/.local/bin/mise"
-      - use
-      - -g
       - "go@{{ go_version }}"

--- a/roles/mise/files/.config/mise/config.toml
+++ b/roles/mise/files/.config/mise/config.toml
@@ -1,0 +1,1 @@
+# Global mise configuration managed by dotfiles.


### PR DESCRIPTION
## 概要
- go role から `mise use -g` を外し、Go の導入をより単純な責務に整理しました
- mise role にグローバル設定ファイル `~/.config/mise/config.toml` を追加しました

## 変更内容
- `roles/go/tasks/main.yml`
  - `mise where` で Go の導入有無を確認
  - 未導入時のみ `mise install go@...` を実行
  - グローバルバージョン固定の `mise use -g` を削除
- `roles/mise/files/.config/mise/config.toml`
  - mise のグローバル設定ファイルを追加

## 意図
- mise は共通基盤、go role は Go の導入だけ、という責務分離を明確にするためです
- 各 role を playbook に含めるかどうかで導入ツールを判断しやすくします

## 確認
- `ansible-playbook --syntax-check -i inventories/production playbook.yml`
