### PR TITLE
[codex] Guard optional fzf helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Repository-specific ignores
 .codex
 .serena
+.DS_Store

--- a/roles/fzf/files/.zsh/conf.d/fzf-function.zsh
+++ b/roles/fzf/files/.zsh/conf.d/fzf-function.zsh
@@ -8,23 +8,27 @@ fda() {
   dir=$(find ${1:-.} -type d 2> /dev/null | fzf +m) && cd "$dir"
 }
 
-tm() {
-  [[ -n "$TMUX" ]] && change="switch-client" || change="attach-session"
-  if [ $1 ]; then
-    tmux $change -t "$1" 2>/dev/null || (tmux new-session -d -s $1 && tmux $change -t "$1"); return
-  fi
-  session=$(tmux list-sessions -F "#{session_name}" 2>/dev/null | fzf --exit-0) &&  tmux $change -t "$session" || echo "No sessions found."
-}
+if (( $+commands[tmux] )); then
+  tm() {
+    [[ -n "$TMUX" ]] && change="switch-client" || change="attach-session"
+    if [ $1 ]; then
+      tmux $change -t "$1" 2>/dev/null || (tmux new-session -d -s $1 && tmux $change -t "$1"); return
+    fi
+    session=$(tmux list-sessions -F "#{session_name}" 2>/dev/null | fzf --exit-0) &&  tmux $change -t "$session" || echo "No sessions found."
+  }
+fi
 
 #unalias z
-z() {
-  if [[ -z "$*" ]]; then
-    cd "$(_z -l 2>&1 | fzf +s --tac | sed 's/^[0-9,.]* *//')"
-  else
-    _last_z_args="$@"
-    _z "$@"
-  fi
-}
+if (( $+commands[_z] || $+functions[_z] )); then
+  z() {
+    if [[ -z "$*" ]]; then
+      cd "$(_z -l 2>&1 | fzf +s --tac | sed 's/^[0-9,.]* *//')"
+    else
+      _last_z_args="$@"
+      _z "$@"
+    fi
+  }
+fi
 
 fkill() {
   local pid
@@ -35,18 +39,29 @@ fkill() {
   fi
 }
 
-fbr() {
-  local branches branch
-  branches=$(git for-each-ref --count=30 --sort=-committerdate refs/heads/ --format="%(refname:short)") &&
-  branch=$(echo "$branches" |
-           fzf-tmux -d $(( 2 + $(wc -l <<< "$branches") )) +m) &&
-  git checkout $(echo "$branch" | sed "s/.* //" | sed "s#remotes/[^/]*/##")
-}
+if (( $+commands[git] && $+commands[fzf-tmux] )); then
+  fbr() {
+    local branches branch
+    branches=$(git for-each-ref --count=30 --sort=-committerdate refs/heads/ --format="%(refname:short)") &&
+    branch=$(echo "$branches" |
+             fzf-tmux -d $(( 2 + $(wc -l <<< "$branches") )) +m) &&
+    git checkout $(echo "$branch" | sed "s/.* //" | sed "s#remotes/[^/]*/##")
+  }
+fi
 
-fs() {
-  local host=$(sshls | fzf)
-  if [ -n "${host}" ]; then
-    echo "Connecting to ${host}..."
-    ssh ${host}
-  fi
-}
+if (( $+commands[sshls] )); then
+  fs() {
+    local host=$(sshls | fzf)
+    if [ -n "${host}" ]; then
+      echo "Connecting to ${host}..."
+      ssh ${host}
+    fi
+  }
+fi
+
+if (( $+commands[ghq] )); then
+  fghq() {
+    local dir
+    dir=$(ghq list --full-path | fzf) && cd "$dir"
+  }
+fi


### PR DESCRIPTION
## Summary

- Wrap fzf helper definitions that depend on optional commands so they are only declared when those commands exist.
- Add `.DS_Store` to repository-specific ignores.

## Impact

Shell startup avoids defining helpers for tools that are not installed, while leaving always-available helper functions unchanged.

## Validation

- `zsh -n projects/dotfiles/roles/fzf/files/.zsh/conf.d/fzf-function.zsh`