### PR TITLE
[codex] mise の conf.d 管理に移行する

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -88,3 +88,4 @@
         - go
         - extra
         - install
+        - link

--- a/roles/git/files/.config/mise/conf.d/ghq.toml
+++ b/roles/git/files/.config/mise/conf.d/ghq.toml
@@ -1,0 +1,2 @@
+[tools]
+ghq = "latest"

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -23,14 +23,18 @@
       - install
       - ghq
 
-- name: Set ghq via mise
-  when: ghq_installation.rc != 0
-  ansible.builtin.command:
-    argv:
-      - "{{ home }}/.local/bin/mise"
-      - use
-      - -g
-      - ghq
+- name: Ensure mise conf.d directory exists
+  ansible.builtin.file:
+    path: "{{ home }}/.config/mise/conf.d"
+    state: directory
+    mode: "0755"
+
+- name: Link ghq mise config
+  ansible.builtin.file:
+    src: "{{ role_path }}/files/.config/mise/conf.d/ghq.toml"
+    dest: "{{ home }}/.config/mise/conf.d/ghq.toml"
+    state: link
+    force: yes
 
 - name: Link .gitconfig
   ansible.builtin.file:

--- a/roles/go/tasks/install.yml
+++ b/roles/go/tasks/install.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Check if go {{ go_version }} is installed
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - where
+      - "go@{{ go_version }}"
+  register: go_exists
+  changed_when: false
+  failed_when: false
+
+- name: Install go {{ go_version }} via mise
+  when: go_exists.rc != 0
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - install
+      - "go@{{ go_version }}"

--- a/roles/go/tasks/link.yml
+++ b/roles/go/tasks/link.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Ensure mise conf.d directory exists
+  ansible.builtin.file:
+    path: "{{ home }}/.config/mise/conf.d"
+    state: directory
+    mode: "0755"
+
+- name: Render go mise config
+  ansible.builtin.template:
+    src: ".config/mise/conf.d/go.toml.j2"
+    dest: "{{ home }}/.config/mise/conf.d/go.toml"
+    mode: "0644"

--- a/roles/go/tasks/main.yml
+++ b/roles/go/tasks/main.yml
@@ -1,19 +1,11 @@
 ---
 
-- name: Check if go {{ go_version }} is installed
-  ansible.builtin.command:
-    argv:
-      - "{{ home }}/.local/bin/mise"
-      - where
-      - "go@{{ go_version }}"
-  register: go_exists
-  changed_when: false
-  failed_when: false
+- name: go | install
+  ansible.builtin.import_tasks: install.yml
+  tags:
+    - install
 
-- name: Install go {{ go_version }}
-  when: go_exists.rc != 0
-  ansible.builtin.command:
-    argv:
-      - "{{ home }}/.local/bin/mise"
-      - install
-      - "go@{{ go_version }}"
+- name: go | link
+  ansible.builtin.import_tasks: link.yml
+  tags:
+    - link

--- a/roles/go/templates/.config/mise/conf.d/go.toml.j2
+++ b/roles/go/templates/.config/mise/conf.d/go.toml.j2
@@ -1,0 +1,2 @@
+[tools]
+go = "{{ go_version }}"


### PR DESCRIPTION
## 概要

`mise` で管理するツールのバージョン定義を `conf.d` 配下へ分離し、`mise use -g` に依存しない構成へ移行しました。

## 変更内容

- `ghq` の有効化を `roles/git/files/.config/mise/conf.d/ghq.toml` のリンクで管理するよう変更
- `go` ロールを `install` / `link` に分割
- `go_version` を使って `mise install go@...` と `conf.d/go.toml` の内容が一致するよう変更
- `playbook.yml` の `go` ロールに `link` タグを追加

## 変更理由

- `mise` のグローバル設定を薄く保ち、各ロールが自分のツール定義を持てるようにするため
- インストール対象と有効化対象のバージョンずれを防ぐため

## 確認内容

- `ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_REMOTE_TEMP=/tmp/ansible-remote ansible-playbook -i inventories/production/hosts.yml playbook.yml --syntax-check`
