### PR TITLE
[node] miseでnodeロールを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ C+q I
   - Python (uv)
   - Rust
   - Go (mise)
+  - Node.js / npm / pnpm (mise)
 
 ---
 ## Commands & Key Config

--- a/playbook.yml
+++ b/playbook.yml
@@ -89,3 +89,10 @@
         - extra
         - install
         - link
+
+    - role: node
+      tags:
+        - node
+        - extra
+        - install
+        - link

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+node_version: "24"
+pnpm_version: "latest"

--- a/roles/node/meta/main.yml
+++ b/roles/node/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+  - role: mise

--- a/roles/node/tasks/install.yml
+++ b/roles/node/tasks/install.yml
@@ -1,0 +1,37 @@
+---
+
+- name: Check if node {{ node_version }} is installed
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - where
+      - "node@{{ node_version }}"
+  register: node_exists
+  changed_when: false
+  failed_when: false
+
+- name: Install node {{ node_version }} via mise
+  when: node_exists.rc != 0
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - install
+      - "node@{{ node_version }}"
+
+- name: Check if pnpm {{ pnpm_version }} is installed
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - where
+      - "pnpm@{{ pnpm_version }}"
+  register: pnpm_exists
+  changed_when: false
+  failed_when: false
+
+- name: Install pnpm {{ pnpm_version }} via mise
+  when: pnpm_exists.rc != 0
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - install
+      - "pnpm@{{ pnpm_version }}"

--- a/roles/node/tasks/link.yml
+++ b/roles/node/tasks/link.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Ensure mise conf.d directory exists
+  ansible.builtin.file:
+    path: "{{ home }}/.config/mise/conf.d"
+    state: directory
+    mode: "0755"
+
+- name: Render node mise config
+  ansible.builtin.template:
+    src: ".config/mise/conf.d/node.toml.j2"
+    dest: "{{ home }}/.config/mise/conf.d/node.toml"
+    mode: "0644"

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+
+- name: node | install
+  ansible.builtin.import_tasks: install.yml
+  tags:
+    - install
+
+- name: node | link
+  ansible.builtin.import_tasks: link.yml
+  tags:
+    - link

--- a/roles/node/templates/.config/mise/conf.d/node.toml.j2
+++ b/roles/node/templates/.config/mise/conf.d/node.toml.j2
@@ -1,0 +1,3 @@
+[tools]
+node = "{{ node_version }}"
+pnpm = "{{ pnpm_version }}"


### PR DESCRIPTION
## 概要
- miseでNode.js 24とpnpmを導入するnodeロールを追加
- playbookにnodeロールを組み込み
- READMEのコンポーネント一覧にNode.js / npm / pnpmを追記

## 補足
- npm用の個別インストールタスクは外し、node本体とpnpmの導入に責務を絞っています
- issue #133 に対応する変更です

## 確認
- ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ansible-playbook --syntax-check -i inventories/production/hosts.yml playbook.yml