### PR TITLE
#163 macOSでHomebrewをroot実行しないよう修正

### DIFF
--- a/roles/C/tasks/main.yml
+++ b/roles/C/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Install C/C++ packages
+- name: Install C/C++ packages (Linux)
   become: true
   ansible.builtin.package:
     name:
@@ -10,3 +10,13 @@
       - lldb
       - cmake
     state: latest
+  when: ansible_facts['system'] == 'Linux'
+
+- name: Install C/C++ packages (macOS)
+  community.general.homebrew:
+    name:
+      - gdb
+      - llvm
+      - cmake
+    state: latest
+  when: ansible_facts['system'] == 'Darwin'

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,12 +1,19 @@
 ---
 
-- name: Upgrade packages
+- name: Upgrade packages (Linux)
   become: true
   ansible.builtin.package:
     name: '*'
     state: latest
+  when: ansible_facts['system'] == 'Linux'
 
-- name: Install common packages
+- name: Upgrade packages (macOS)
+  community.general.homebrew:
+    update_homebrew: true
+    upgrade_all: true
+  when: ansible_facts['system'] == 'Darwin'
+
+- name: Install common packages (Linux)
   become: true
   ansible.builtin.package:
     name:
@@ -16,3 +23,14 @@
       - snapd
       - "{{ 'libssl-dev' if ansible_pkg_mgr == 'apt' else 'openssl-devel' }}"
     state: latest
+  when: ansible_facts['system'] == 'Linux'
+
+- name: Install common packages (macOS)
+  community.general.homebrew:
+    name:
+      - curl
+      - wget
+      - git
+      - openssl
+    state: latest
+  when: ansible_facts['system'] == 'Darwin'

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -1,9 +1,16 @@
 ---
-- name: Install git
+- name: Install git (Linux)
   become: yes
   ansible.builtin.package:
     name: git
     state: present
+  when: ansible_facts['system'] == 'Linux'
+
+- name: Install git (macOS)
+  community.general.homebrew:
+    name: git
+    state: latest
+  when: ansible_facts['system'] == 'Darwin'
 
 - name: Check if ghq is installed via mise
   ansible.builtin.command:

--- a/roles/neovim/tasks/install.yml
+++ b/roles/neovim/tasks/install.yml
@@ -1,7 +1,14 @@
 ---
 
-- name: Install neovim
+- name: Install neovim (Linux)
   become: true
   ansible.builtin.package:
     name: neovim
     state: latest
+  when: ansible_facts['system'] == 'Linux'
+
+- name: Install neovim (macOS)
+  community.general.homebrew:
+    name: neovim
+    state: latest
+  when: ansible_facts['system'] == 'Darwin'

--- a/roles/tmux/tasks/install.yml
+++ b/roles/tmux/tasks/install.yml
@@ -1,10 +1,17 @@
 ---
 
-- name: Install tmux
+- name: Install tmux (Linux)
   become: true
   ansible.builtin.package:
     name: tmux
     state: latest
+  when: ansible_facts['system'] == 'Linux'
+
+- name: Install tmux (macOS)
+  community.general.homebrew:
+    name: tmux
+    state: latest
+  when: ansible_facts['system'] == 'Darwin'
 
 - name: Clone tpm
   ansible.builtin.git:

--- a/roles/vim/tasks/install.yml
+++ b/roles/vim/tasks/install.yml
@@ -1,7 +1,14 @@
 ---
 
-- name: Install vim
+- name: Install vim (Linux)
   become: true
   ansible.builtin.package:
     name: vim
     state: latest
+  when: ansible_facts['system'] == 'Linux'
+
+- name: Install vim (macOS)
+  community.general.homebrew:
+    name: vim
+    state: latest
+  when: ansible_facts['system'] == 'Darwin'


### PR DESCRIPTION
## 概要
- #163 の原因だった、macOS 上で ansible.builtin.package + become により Homebrew が root 実行される問題を解消
- git/common/C/vim/tmux/neovim のインストールタスクを OS 分岐化
- Linux は既存どおり package + become、macOS は community.general.homebrew（非 root）に統一

## 変更ファイル
- roles/git/tasks/main.yml
- roles/common/tasks/main.yml
- roles/C/tasks/main.yml
- roles/vim/tasks/install.yml
- roles/tmux/tasks/install.yml
- roles/neovim/tasks/install.yml

## 確認手順
- ansible-playbook --syntax-check -i inventories/production/hosts.yml playbook.yml
- ansible-playbook -i inventories/production/hosts.yml playbook.yml --tags git,common,C,vim,tmux,neovim --check
