### PR TITLE
linkタスクの構成とshared helperを整理

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -12,6 +12,8 @@
       tags:
         - git
         - minimum
+        - install
+        - link
 
     - role: cli_tools
       tags:
@@ -22,6 +24,8 @@
       tags:
         - docker
         - extra
+        - install
+        - link
 
     - role: zsh
       tags:
@@ -67,6 +71,8 @@
       tags:
         - rust
         - extra
+        - install
+        - link
 
     - role: mise
       tags:

--- a/roles/docker/tasks/install.yml
+++ b/roles/docker/tasks/install.yml
@@ -1,0 +1,57 @@
+---
+- name: Install dependencies for Docker (apt)
+  become: true
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - curl
+      - gnupg
+    state: present
+  when: ansible_pkg_mgr == 'apt'
+
+- name: Add Docker GPG key (apt)
+  become: true
+  ansible.builtin.apt_key:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    state: present
+  when: ansible_pkg_mgr == 'apt'
+
+- name: Add Docker repository (apt)
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+    state: present
+  when: ansible_pkg_mgr == 'apt'
+
+- name: Install dnf-plugins-core (dnf)
+  become: true
+  ansible.builtin.dnf:
+    name: dnf-plugins-core
+    state: present
+  when: ansible_pkg_mgr == 'dnf'
+
+- name: Add Docker repository (dnf)
+  become: true
+  ansible.builtin.shell:
+    cmd: dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+    creates: /etc/yum.repos.d/docker-ce.repo
+  when: ansible_pkg_mgr == 'dnf'
+
+- name: Install Docker components
+  become: true
+  ansible.builtin.package:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
+    state: present
+    update_cache: true
+
+- name: Ensure Docker service is started and enabled
+  become: true
+  ansible.builtin.service:
+    name: docker
+    state: started
+    enabled: true

--- a/roles/docker/tasks/link.yml
+++ b/roles/docker/tasks/link.yml
@@ -1,0 +1,5 @@
+---
+- name: Link docker files
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/link_filetree.yml"
+  vars:
+    _root: "{{ role_path }}/files/"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,64 +1,10 @@
 ---
-- name: Install dependencies for Docker (apt)
-  become: true
-  ansible.builtin.apt:
-    name:
-      - ca-certificates
-      - curl
-      - gnupg
-    state: present
-  when: ansible_pkg_mgr == 'apt'
+- name: docker | install
+  ansible.builtin.import_tasks: install.yml
+  tags:
+    - install
 
-- name: Add Docker GPG key (apt)
-  become: true
-  ansible.builtin.apt_key:
-    url: https://download.docker.com/linux/ubuntu/gpg
-    state: present
-  when: ansible_pkg_mgr == 'apt'
-
-- name: Add Docker repository (apt)
-  become: true
-  ansible.builtin.apt_repository:
-    repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
-    state: present
-  when: ansible_pkg_mgr == 'apt'
-
-- name: Install dnf-plugins-core (dnf)
-  become: true
-  ansible.builtin.dnf:
-    name: dnf-plugins-core
-    state: present
-  when: ansible_pkg_mgr == 'dnf'
-
-- name: Add Docker repository (dnf)
-  become: true
-  ansible.builtin.shell:
-    cmd: dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-    creates: /etc/yum.repos.d/docker-ce.repo
-  when: ansible_pkg_mgr == 'dnf'
-
-- name: Install Docker components
-  become: true
-  ansible.builtin.package:
-    name:
-      - docker-ce
-      - docker-ce-cli
-      - containerd.io
-      - docker-buildx-plugin
-      - docker-compose-plugin
-    state: present
-    update_cache: true
-
-- name: Ensure Docker service is started and enabled
-  become: true
-  ansible.builtin.service:
-    name: docker
-    state: started
-    enabled: true
-
-- name: Link docker.zsh completion
-  ansible.builtin.file:
-    src: "{{ role_path }}/files/.zsh/conf.d/docker.zsh"
-    dest: "{{ home }}/.zsh/conf.d/docker.zsh"
-    state: link
-    force: true
+- name: docker | link
+  ansible.builtin.import_tasks: link.yml
+  tags:
+    - link

--- a/roles/fzf/tasks/link.yml
+++ b/roles/fzf/tasks/link.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Link fzf config tree
-  ansible.builtin.import_tasks: ../../shared/tasks/link_filetree.yml
+- name: Link fzf files
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/link_filetree.yml"
   vars:
-    _filetree_root: "{{ role_path }}/files/"
+    _root: "{{ role_path }}/files/"

--- a/roles/git/tasks/install.yml
+++ b/roles/git/tasks/install.yml
@@ -1,0 +1,31 @@
+---
+- name: Install git (Linux)
+  become: yes
+  ansible.builtin.package:
+    name: git
+    state: present
+  when: ansible_facts['system'] == 'Linux'
+
+- name: Install git (macOS)
+  community.general.homebrew:
+    name: git
+    state: latest
+  when: ansible_facts['system'] == 'Darwin'
+
+- name: Check if ghq is installed via mise
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - where
+      - ghq
+  register: ghq_installation
+  changed_when: false
+  failed_when: false
+
+- name: Install ghq via mise
+  when: ghq_installation.rc != 0
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - install
+      - ghq

--- a/roles/git/tasks/link.yml
+++ b/roles/git/tasks/link.yml
@@ -1,0 +1,7 @@
+---
+- name: Link git files
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/link_filetree.yml"
+  vars:
+    _root: "{{ role_path }}/files/"
+    _link_force_overrides:
+      .gitconfig.local: false

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -1,65 +1,10 @@
 ---
-- name: Install git (Linux)
-  become: yes
-  ansible.builtin.package:
-    name: git
-    state: present
-  when: ansible_facts['system'] == 'Linux'
+- name: git | install
+  ansible.builtin.import_tasks: install.yml
+  tags:
+    - install
 
-- name: Install git (macOS)
-  community.general.homebrew:
-    name: git
-    state: latest
-  when: ansible_facts['system'] == 'Darwin'
-
-- name: Check if ghq is installed via mise
-  ansible.builtin.command:
-    argv:
-      - "{{ home }}/.local/bin/mise"
-      - where
-      - ghq
-  register: ghq_installation
-  changed_when: false
-  failed_when: false
-
-- name: Install ghq via mise
-  when: ghq_installation.rc != 0
-  ansible.builtin.command:
-    argv:
-      - "{{ home }}/.local/bin/mise"
-      - install
-      - ghq
-
-- name: Ensure mise conf.d directory exists
-  ansible.builtin.file:
-    path: "{{ home }}/.config/mise/conf.d"
-    state: directory
-    mode: "0755"
-
-- name: Link ghq mise config
-  ansible.builtin.file:
-    src: "{{ role_path }}/files/.config/mise/conf.d/ghq.toml"
-    dest: "{{ home }}/.config/mise/conf.d/ghq.toml"
-    state: link
-    force: yes
-
-- name: Link .gitconfig
-  ansible.builtin.file:
-    src: "{{ role_path }}/files/.gitconfig"
-    dest: "{{ home }}/.gitconfig"
-    state: link
-    force: yes
-
-- name: Link .gitconfig.local template
-  ansible.builtin.file:
-    src: "{{ role_path }}/files/.gitconfig.local"
-    dest: "{{ home }}/.gitconfig.local"
-    state: link
-    force: no
-
-- name: Link .gitignore to home directory
-  ansible.builtin.file:
-    src: "{{ role_path }}/files/.gitignore"
-    dest: "{{ home }}/.gitignore"
-    state: link
-    force: yes
+- name: git | link
+  ansible.builtin.import_tasks: link.yml
+  tags:
+    - link

--- a/roles/go/tasks/link.yml
+++ b/roles/go/tasks/link.yml
@@ -1,13 +1,5 @@
 ---
-
-- name: Ensure mise conf.d directory exists
-  ansible.builtin.file:
-    path: "{{ home }}/.config/mise/conf.d"
-    state: directory
-    mode: "0755"
-
-- name: Render go mise config
-  ansible.builtin.template:
-    src: ".config/mise/conf.d/go.toml.j2"
-    dest: "{{ home }}/.config/mise/conf.d/go.toml"
-    mode: "0644"
+- name: Render go files
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/render_filetree.yml"
+  vars:
+    _root: "{{ role_path }}/templates/"

--- a/roles/mise/tasks/link.yml
+++ b/roles/mise/tasks/link.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Link mise config tree
-  ansible.builtin.import_tasks: ../../shared/tasks/link_filetree.yml
+- name: Link mise files
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/link_filetree.yml"
   vars:
-    _filetree_root: "{{ role_path }}/files/"
+    _root: "{{ role_path }}/files/"

--- a/roles/neovim/tasks/link.yml
+++ b/roles/neovim/tasks/link.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Link neovim config tree
-  ansible.builtin.import_tasks: ../../shared/tasks/link_filetree.yml
+- name: Link neovim files
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/link_filetree.yml"
   vars:
-    _filetree_root: "{{ role_path }}/files/"
+    _root: "{{ role_path }}/files/"

--- a/roles/node/tasks/link.yml
+++ b/roles/node/tasks/link.yml
@@ -1,13 +1,5 @@
 ---
-
-- name: Ensure mise conf.d directory exists
-  ansible.builtin.file:
-    path: "{{ home }}/.config/mise/conf.d"
-    state: directory
-    mode: "0755"
-
-- name: Render node mise config
-  ansible.builtin.template:
-    src: ".config/mise/conf.d/node.toml.j2"
-    dest: "{{ home }}/.config/mise/conf.d/node.toml"
-    mode: "0644"
+- name: Render node files
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/render_filetree.yml"
+  vars:
+    _root: "{{ role_path }}/templates/"

--- a/roles/rust/tasks/install.yml
+++ b/roles/rust/tasks/install.yml
@@ -1,0 +1,36 @@
+---
+- name: Check if cargo is installed
+  ansible.builtin.stat:
+    path: "{{ home }}/.cargo/bin/cargo"
+  register: cargo_binary
+
+- name: Download Rust installer
+  when: not cargo_binary.stat.exists
+  ansible.builtin.get_url:
+    url: https://sh.rustup.rs
+    dest: /tmp/sh.rustup.rs
+    mode: "0755"
+    force: true
+
+- name: Install Rust
+  when: not cargo_binary.stat.exists
+  ansible.builtin.command:
+    argv:
+      - /tmp/sh.rustup.rs
+      - -y
+  args:
+    creates: "{{ home }}/.cargo/bin/cargo"
+
+- name: Update Rust
+  when: cargo_binary.stat.exists
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.cargo/bin/rustup"
+      - update
+
+- name: Install cargo-update
+  community.general.cargo:
+    name: cargo-update
+  environment:
+    PATH: "{{ home }}/.cargo/bin:{{ ansible_facts['env']['PATH'] }}"
+  ignore_errors: true

--- a/roles/rust/tasks/link.yml
+++ b/roles/rust/tasks/link.yml
@@ -1,0 +1,7 @@
+---
+- name: Link rust files
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/link_filetree.yml"
+  vars:
+    _root: "{{ role_path }}/files/"
+
+# https://waylonwalker.com/install-rust/

--- a/roles/rust/tasks/main.yml
+++ b/roles/rust/tasks/main.yml
@@ -1,45 +1,10 @@
 ---
+- name: rust | install
+  ansible.builtin.import_tasks: install.yml
+  tags:
+    - install
 
-- name: Check if cargo is installed
-  ansible.builtin.stat:
-    path: "{{ home }}/.cargo/bin/cargo"
-  register: cargo_binary
-
-- name: Download Rust installer
-  when: not cargo_binary.stat.exists
-  ansible.builtin.get_url:
-    url: https://sh.rustup.rs
-    dest: /tmp/sh.rustup.rs
-    mode: '0755'
-    force: true
-
-- name: Install Rust
-  when: not cargo_binary.stat.exists
-  ansible.builtin.command:
-    argv:
-      - /tmp/sh.rustup.rs
-      - -y
-  args:
-    creates: "{{ home }}/.cargo/bin/cargo"
-
-- name: Update Rust
-  when: cargo_binary.stat.exists
-  ansible.builtin.command:
-    argv:
-      - "{{ home }}/.cargo/bin/rustup"
-      - update
-
-- name: Install "cargo-update"
-  community.general.cargo:
-    name: cargo-update
-  environment:
-    PATH: "{{ home }}/.cargo/bin:{{ ansible_facts['env']['PATH'] }}"
-  ignore_errors: true
-
-- name: Link rust config
-  ansible.builtin.file:
-    src: "{{ role_path }}/files/.zsh/conf.d/rust.zsh"
-    dest: "{{ home }}/.zsh/conf.d/rust.zsh"
-    state: link
-
-# https://waylonwalker.com/install-rust/
+- name: rust | link
+  ansible.builtin.import_tasks: link.yml
+  tags:
+    - link

--- a/roles/shared/tasks/link_filetree.yml
+++ b/roles/shared/tasks/link_filetree.yml
@@ -1,27 +1,27 @@
 ---
 # Required:
-# - _filetree_root: path to role files root (e.g. "{{ role_path }}/files/")
+# - _root: path to role files root (e.g. "{{ role_path }}/files/")
 # Optional:
 # - _dir_mode: directory mode (default "0755")
 # - _link_force: force symlink overwrite (default true)
 
-- name: Collect config tree entries
+- name: Collect link entries
   ansible.builtin.set_fact:
-    _filetree_items: "{{ lookup('community.general.filetree', _filetree_root, wantlist=True) }}"
+    _entries: "{{ lookup('community.general.filetree', _root, wantlist=True) }}"
 
-- name: Ensure config directories exist
+- name: Ensure link dirs
   ansible.builtin.file:
     path: "{{ home }}/{{ item.path }}"
     state: directory
     mode: "{{ _dir_mode | default('0755') }}"
-  loop: "{{ _filetree_items }}"
+  loop: "{{ _entries }}"
   when: item.state == 'directory'
 
-- name: Link configuration files
+- name: Link files
   ansible.builtin.file:
     src: "{{ item.src }}"
     dest: "{{ home }}/{{ item.path }}"
     state: link
     force: "{{ _link_force | default(true) }}"
-  loop: "{{ _filetree_items }}"
+  loop: "{{ _entries }}"
   when: item.state == 'file'

--- a/roles/shared/tasks/render_filetree.yml
+++ b/roles/shared/tasks/render_filetree.yml
@@ -1,16 +1,15 @@
 ---
 # Required:
-# - _root: path to role files root (e.g. "{{ role_path }}/files/")
+# - _root: path to role templates root (e.g. "{{ role_path }}/templates/")
 # Optional:
 # - _dir_mode: directory mode (default "0755")
-# - _link_force: force symlink overwrite (default true)
-# - _link_force_overrides: per-path force overrides
+# - _file_mode: rendered file mode (default "0644")
 
-- name: Collect link entries
+- name: Collect render entries
   ansible.builtin.set_fact:
     _entries: "{{ lookup('community.general.filetree', _root, wantlist=True) }}"
 
-- name: Ensure link dirs
+- name: Ensure render dirs
   ansible.builtin.file:
     path: "{{ home }}/{{ item.path }}"
     state: directory
@@ -18,11 +17,10 @@
   loop: "{{ _entries }}"
   when: item.state == 'directory'
 
-- name: Link files
-  ansible.builtin.file:
+- name: Render files
+  ansible.builtin.template:
     src: "{{ item.src }}"
-    dest: "{{ home }}/{{ item.path }}"
-    state: link
-    force: "{{ _link_force_overrides[item.path] | default(_link_force | default(true)) }}"
+    dest: "{{ home }}/{{ item.path | regex_replace('\\.j2$', '') }}"
+    mode: "{{ _file_mode | default('0644') }}"
   loop: "{{ _entries }}"
   when: item.state == 'file'

--- a/roles/tmux/tasks/link.yml
+++ b/roles/tmux/tasks/link.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Link tmux config tree
-  ansible.builtin.import_tasks: ../../shared/tasks/link_filetree.yml
+- name: Link tmux files
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/link_filetree.yml"
   vars:
-    _filetree_root: "{{ role_path }}/files/"
+    _root: "{{ role_path }}/files/"

--- a/roles/uv/tasks/link.yml
+++ b/roles/uv/tasks/link.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Link uv config tree
-  ansible.builtin.import_tasks: ../../shared/tasks/link_filetree.yml
+- name: Link uv files
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/link_filetree.yml"
   vars:
-    _filetree_root: "{{ role_path }}/files/"
+    _root: "{{ role_path }}/files/"

--- a/roles/vim/tasks/link.yml
+++ b/roles/vim/tasks/link.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Link vim config tree
-  ansible.builtin.import_tasks: ../../shared/tasks/link_filetree.yml
+- name: Link vim files
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/link_filetree.yml"
   vars:
-    _filetree_root: "{{ role_path }}/files/"
+    _root: "{{ role_path }}/files/"

--- a/roles/zsh/tasks/link.yml
+++ b/roles/zsh/tasks/link.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Link zsh config tree
-  ansible.builtin.import_tasks: ../../shared/tasks/link_filetree.yml
+- name: Link zsh files
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/link_filetree.yml"
   vars:
-    _filetree_root: "{{ role_path }}/files/"
+    _root: "{{ role_path }}/files/"


### PR DESCRIPTION
## 概要
- link helper の import_tasks を playbook_dir ベースのパスに統一
- shared helper 周辺の task 名と変数名を簡潔に整理
- git / docker / rust を main.yml -> install.yml / link.yml に分離
- go / node を含む link role の責務を shared helper ベースで整理
- templates ツリーを描画する shared helper を追加

## 背景
- role ごとに link タスクの構成や見え方が揃っておらず、main.yml の中に link 処理が直接残る role もあった
- relative path の import と helper 周辺の命名も少し追いづらかった
- file ベースと template ベースで、shared に寄せる形も揃えたかった

## 変更内容
- git / docker / rust:
  main.yml から install/link を分離し、main.yml は入口だけに統一
- zsh / fzf / tmux / vim / neovim / mise / uv / git / docker / rust:
  roles/shared/tasks/link_filetree.yml を使う形に統一
- go / node:
  roles/shared/tasks/render_filetree.yml を使い、templates ツリーをそのまま描画する形に統一
- git の .gitconfig.local:
  既存どおり force: false を保つため、shared helper 側に path ごとの force override を追加

## 確認
- ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_REMOTE_TEMP=/tmp/ansible-remote ansible-playbook -i inventories/production/hosts.yml playbook.yml --syntax-check

## 関連
- closes #161
- refs #162
