### PR TITLE
#160 installer実行タスクの冪等性を整理する

### DIFF
--- a/roles/docker/tasks/install.yml
+++ b/roles/docker/tasks/install.yml
@@ -32,8 +32,12 @@
 
 - name: Add Docker repository (dnf)
   become: true
-  ansible.builtin.shell:
-    cmd: dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+  ansible.builtin.command:
+    argv:
+      - dnf
+      - config-manager
+      - --add-repo
+      - https://download.docker.com/linux/centos/docker-ce.repo
     creates: /etc/yum.repos.d/docker-ce.repo
   when: ansible_pkg_mgr == 'dnf'
 

--- a/roles/fzf/tasks/install.yml
+++ b/roles/fzf/tasks/install.yml
@@ -14,7 +14,7 @@
   register: fzf_binary
   when: ansible_facts['system'] == 'Linux'
 
-- name: Install & Update fzf (Linux)
+- name: Install or update fzf shell integration (Linux)
   ansible.builtin.command:
     argv:
       - "{{ home }}/.fzf/install"

--- a/roles/fzf/tasks/install.yml
+++ b/roles/fzf/tasks/install.yml
@@ -5,11 +5,28 @@
     repo: https://github.com/junegunn/fzf.git
     dest: "{{ home }}/.fzf"
     version: master
+  register: fzf_repo
+  when: ansible_facts['system'] == 'Linux'
+
+- name: Check if fzf binary is installed (Linux)
+  ansible.builtin.stat:
+    path: "{{ home }}/.fzf/bin/fzf"
+  register: fzf_binary
   when: ansible_facts['system'] == 'Linux'
 
 - name: Install & Update fzf (Linux)
-  ansible.builtin.shell: $HOME/.fzf/install --no-key-bindings --no-completion --no-update-rc --no-bash --no-zsh --no-fish
-  when: ansible_facts['system'] == 'Linux'
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.fzf/install"
+      - --no-key-bindings
+      - --no-completion
+      - --no-update-rc
+      - --no-bash
+      - --no-zsh
+      - --no-fish
+  when:
+    - ansible_facts['system'] == 'Linux'
+    - fzf_repo.changed or not fzf_binary.stat.exists
 
 - name: Install fzf (macOS)
   community.general.homebrew:

--- a/roles/git/tasks/install.yml
+++ b/roles/git/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install git (Linux)
-  become: yes
+  become: true
   ansible.builtin.package:
     name: git
     state: present
@@ -18,12 +18,12 @@
       - "{{ home }}/.local/bin/mise"
       - where
       - ghq
-  register: ghq_installation
+  register: ghq_exists
   changed_when: false
   failed_when: false
 
 - name: Install ghq via mise
-  when: ghq_installation.rc != 0
+  when: ghq_exists.rc != 0
   ansible.builtin.command:
     argv:
       - "{{ home }}/.local/bin/mise"

--- a/roles/rust/tasks/install.yml
+++ b/roles/rust/tasks/install.yml
@@ -21,16 +21,28 @@
   args:
     creates: "{{ home }}/.cargo/bin/cargo"
 
-- name: Update Rust
+- name: Check for Rust toolchain updates
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.cargo/bin/rustup"
+      - check
+  register: rustup_update_check
+  changed_when: false
   when: cargo_binary.stat.exists
+
+- name: Update Rust toolchains
   ansible.builtin.command:
     argv:
       - "{{ home }}/.cargo/bin/rustup"
       - update
+  when:
+    - cargo_binary.stat.exists
+    - "'Update available' in rustup_update_check.stdout"
 
 - name: Install cargo-update
   community.general.cargo:
     name: cargo-update
+  register: cargo_update_install
   environment:
     PATH: "{{ home }}/.cargo/bin:{{ ansible_facts['env']['PATH'] }}"
-  ignore_errors: true
+  failed_when: false

--- a/roles/uv/tasks/install.yml
+++ b/roles/uv/tasks/install.yml
@@ -21,10 +21,23 @@
   args:
     creates: "{{ home }}/.local/bin/uv"
 
-- name: Update uv
-  when: uv_binary.stat.exists
+- name: Check for uv updates
   ansible.builtin.command:
     argv:
       - "{{ home }}/.local/bin/uv"
       - self
       - update
+      - --dry-run
+  register: uv_update_check
+  changed_when: false
+  when: uv_binary.stat.exists
+
+- name: Update uv
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/uv"
+      - self
+      - update
+  when:
+    - uv_binary.stat.exists
+    - "'Would update uv' in uv_update_check.stdout"


### PR DESCRIPTION
## 概要

installer 系 role の実行判定と命名を整理し、再実行時の changed 判定を追いやすくしました。

## 変更内容

- `fzf` の installer 実行を、未導入または clone 更新時だけ走るように整理
- `docker` の DNF repository 追加を `shell` から `command` に変更
- `uv` と `rustup` を「更新確認」と「更新実行」に分け、更新がある時だけ更新処理を実行
- `git` role の `ghq` 導入判定名を他 role と揃えて読みやすく整理
- `rust` role の `ignore_errors` をやめて non-fatal を明示

## 背景

`shell` / `command` ベースの installer 処理が role ごとに少しずつ異なっており、何度流した時に changed になるのか追いにくい状態でした。#160 の一環として、代表的な installer task から idempotent に寄せています。

## 確認したこと

- `ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_REMOTE_TEMP=/tmp/ansible-remote ansible-playbook -i inventories/production/hosts.yml playbook.yml --syntax-check`
- `ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_REMOTE_TEMP=/tmp/ansible-remote ansible-lint playbook.yml`
  - 既存の `package-latest` / `meta-no-info` 指摘は継続
- `~/.local/bin/uv self update --dry-run`
- `~/.cargo/bin/rustup check`

## 補足

- `ansible-playbook --check --tags fzf,rust,uv` はローカルの `sudo` 設定不整合により `zsh` role で失敗するため、今回は syntax-check と lint を主な検証にしています
- 既存の `roles/git/files/.gitconfig.local` 変更はこの PR に含めていません

Refs #160
