### PR TITLE
[codex] mise利用ロールのinstallタスクをshared helper化する

### DIFF
--- a/roles/git/tasks/install.yml
+++ b/roles/git/tasks/install.yml
@@ -12,20 +12,7 @@
     state: latest
   when: ansible_facts['system'] == 'Darwin'
 
-- name: Check if ghq is installed via mise
-  ansible.builtin.command:
-    argv:
-      - "{{ home }}/.local/bin/mise"
-      - where
-      - ghq
-  register: ghq_exists
-  changed_when: false
-  failed_when: false
-
-- name: Install ghq via mise
-  when: ghq_exists.rc != 0
-  ansible.builtin.command:
-    argv:
-      - "{{ home }}/.local/bin/mise"
-      - install
-      - ghq
+- name: Install ghq via shared mise helper
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/install_mise_tool.yml"
+  vars:
+    _mise_tool_spec: ghq

--- a/roles/go/tasks/install.yml
+++ b/roles/go/tasks/install.yml
@@ -1,19 +1,5 @@
 ---
-
-- name: Check if go {{ go_version }} is installed
-  ansible.builtin.command:
-    argv:
-      - "{{ home }}/.local/bin/mise"
-      - where
-      - "go@{{ go_version }}"
-  register: go_exists
-  changed_when: false
-  failed_when: false
-
-- name: Install go {{ go_version }} via mise
-  when: go_exists.rc != 0
-  ansible.builtin.command:
-    argv:
-      - "{{ home }}/.local/bin/mise"
-      - install
-      - "go@{{ go_version }}"
+- name: Install go via shared mise helper
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/install_mise_tool.yml"
+  vars:
+    _mise_tool_spec: "go@{{ go_version }}"

--- a/roles/node/tasks/install.yml
+++ b/roles/node/tasks/install.yml
@@ -1,37 +1,10 @@
 ---
+- name: Install node via shared mise helper
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/install_mise_tool.yml"
+  vars:
+    _mise_tool_spec: "node@{{ node_version }}"
 
-- name: Check if node {{ node_version }} is installed
-  ansible.builtin.command:
-    argv:
-      - "{{ home }}/.local/bin/mise"
-      - where
-      - "node@{{ node_version }}"
-  register: node_exists
-  changed_when: false
-  failed_when: false
-
-- name: Install node {{ node_version }} via mise
-  when: node_exists.rc != 0
-  ansible.builtin.command:
-    argv:
-      - "{{ home }}/.local/bin/mise"
-      - install
-      - "node@{{ node_version }}"
-
-- name: Check if pnpm {{ pnpm_version }} is installed
-  ansible.builtin.command:
-    argv:
-      - "{{ home }}/.local/bin/mise"
-      - where
-      - "pnpm@{{ pnpm_version }}"
-  register: pnpm_exists
-  changed_when: false
-  failed_when: false
-
-- name: Install pnpm {{ pnpm_version }} via mise
-  when: pnpm_exists.rc != 0
-  ansible.builtin.command:
-    argv:
-      - "{{ home }}/.local/bin/mise"
-      - install
-      - "pnpm@{{ pnpm_version }}"
+- name: Install pnpm via shared mise helper
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/install_mise_tool.yml"
+  vars:
+    _mise_tool_spec: "pnpm@{{ pnpm_version }}"

--- a/roles/shared/tasks/install_mise_tool.yml
+++ b/roles/shared/tasks/install_mise_tool.yml
@@ -1,0 +1,21 @@
+---
+# Required:
+# - _mise_tool_spec: tool spec passed to `mise where/install` (e.g. "go@latest")
+
+- name: Check if {{ _mise_tool_spec }} is installed via mise
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - where
+      - "{{ _mise_tool_spec }}"
+  register: _mise_tool_exists
+  changed_when: false
+  failed_when: false
+
+- name: Install {{ _mise_tool_spec }} via mise
+  when: _mise_tool_exists.rc != 0
+  ansible.builtin.command:
+    argv:
+      - "{{ home }}/.local/bin/mise"
+      - install
+      - "{{ _mise_tool_spec }}"


### PR DESCRIPTION
## 概要
- `mise where` / `mise install` の共通フローを shared helper task に切り出し
- `go` / `node` / `git` role の install task を helper 呼び出しに置き換え
- shared task の呼び出し方を既存の link task と同じ `{{ playbook_dir }}` ベースに統一

## 変更理由
- mise 管理ツールの install フローが role ごとに重複していたため
- 今後 tool を追加するときの変更箇所を明確にしたいため

## 確認したこと
- `ANSIBLE_LOCAL_TEMP=/tmp/.ansible-local ANSIBLE_REMOTE_TEMP=/tmp/.ansible-remote XDG_CACHE_HOME=/tmp/.cache ansible-playbook -i inventories/production/hosts.yml playbook.yml --syntax-check`

Closes #171