### PR TITLE
cli_toolsでcargo実行時のPATHを補う

### DIFF
--- a/roles/cli_tools/tasks/main.yml
+++ b/roles/cli_tools/tasks/main.yml
@@ -3,6 +3,8 @@
 - name: Install cargo packages
   community.general.cargo:
     name: "{{ item }}"
+  environment:
+    PATH: "{{ home }}/.cargo/bin:{{ ansible_facts['env']['PATH'] }}"
   loop:
     - eza
     - git-delta


### PR DESCRIPTION
## 概要
- `cli_tools` role の `community.general.cargo` 実行時に `~/.cargo/bin` を `PATH` へ追加
- `rustup` 直後の同一 play でも cargo バイナリを解決できるように調整

## 原因
- `cli_tools` role は `rust` role に依存しているため実行順自体は問題なかった
- 一方で `community.general.cargo` は `cargo` が `bin path` にあることを前提としており、導入直後の `PATH` が不足して失敗しうる状態だった

## 確認したこと
- `ansible-playbook -i inventories/production/hosts.yml playbook.yml --syntax-check`

Refs #177