### PR TITLE
init.shとREADMEを整理する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,5 @@
 # dotfiles
 
-<details>
-<summary>Table of Contents</summary>
-
-## TOC
-- [dotfiles](#dotfiles)
-  - [TOC](#toc)
-  - [Installation](#installation)
-  - [ScreenShot](#screenshot)
-  - [Components](#components)
-  - [Commands \& Key Config](#commands--key-config)
-    - [shell command](#shell-command)
-    - [git](#git)
-    - [tmux](#tmux)
-  - [参考](#参考)
-
-</details>
-
 ---
 ## Installation
 ```bash
@@ -25,66 +8,75 @@ bash -c "$(curl -L raw.github.com/Sakurai00/dotfiles/master/init.sh)"
 
 ```bash
 chsh -s $(which zsh)
-
-zsh
-tmux
-C+q I
 ```
 
 ---
-## ScreenShot
-![](https://user-images.githubusercontent.com/54164011/120113830-440fe380-c1b7-11eb-9cb4-56a770d772c4.png)
-
----
 ## Components
-- Terminal
-  - tmux
-
 - Shell
-  - Zsh (Powerlevel10k)
-    - zinit
+  - zsh
+    - Plugin manager: zinit
+    - Prompt: Powerlevel10k
+  - Fuzzy finder: fzf
 
-- Editor
-  - neovim (ayu mirage)
-    - dein.vim
+- Multiplexer
+  - tmux
+    - tmux plugin manager: TPM
 
-- Lang
+- Editors
+  - Neovim
+  - Vim
+
+- Languages
   - C/C++
-  - Python (uv)
+  - Python
+    - Package manager: uv
   - Rust
-  - Go (mise)
-  - Node.js / npm / pnpm (mise)
+    - Package manager: Cargo
+  - Go
+    - Runtime manager: mise
+  - Node.js
+    - Runtime manager: mise
+  - pnpm
+    - Runtime manager: mise
+
+- Containers
+  - Docker
 
 ---
 ## Commands & Key Config
 
 ### shell command
 ```bash
-alias ls="exa -F"
-alias lt="exa -aT -I '.git|.github'"
-alias ll="exa -alF --git"
-alias llt="exa -alFT -I '.git'"
-alias cp="cp -i"
-alias mv="mv -i"
-alias rm="rm -i"
+alias ls="eza -F"
+alias lt='eza -aT -I ".git|.github"'
+alias ll="eza -alF --git"
+alias llt='eza -alFT -I ".git"'
+alias cpi="cp -i"
+alias mvi="mv -i"
+alias rmi="rm -i"
 alias his="history"
 alias relogin="exec $SHELL -l"
+alias g="git"
 alias vim="nvim"
-alias cat="batcat"
+alias cat="bat"
+alias tm3='tmux new-session \; split-window -h \; split-window -v \;'
 ```
 ### git
 ```bash
 [alias]
 	st = status -sb
+	co = checkout
+	sw = switch
+	br = branch
+	ci = commit
+	ca = commit --amend --no-edit
+	pl = pull
 	df = diff --color-words -w
-	tree = log --graph --oneline
-	logl = log --date=format:'%Y/%m/%d %H:%M:%S' --pretty=format:'%C(green)%h %C(reset)%cd %C(blue)%cn %C(red)%d %C(reset)%s'
+	unstage = restore --staged
+	l = log --date=format:'%Y/%m/%d %H:%M:%S' --pretty=format:'%C(green)%h %C(reset)%cd %C(blue)%cn %C(red)%d %C(reset)%s'
+	graph = log --graph --pretty=format:'%C(yellow)%h%C(reset) -%C(auto)%d%C(reset) %s %C(green)(%cr) %C(bold blue)<%an>%C(reset)'
 ```
 ### tmux
 - Prefix C-q
-
-
-## 参考
-https://github.com/topics/dotfiles
-https://wiki.archlinux.jp/index.php/%E3%83%89%E3%83%83%E3%83%88%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB
-https://github.com/b4b4r07/dotfiles
+- Split panes: `|` / `-`
+- Move panes: `h` `j` `k` `l`

--- a/init.sh
+++ b/init.sh
@@ -1,56 +1,221 @@
-#!/bin/bash -x
+#!/usr/bin/env bash
+set -euo pipefail
 
 # bash -c "$(curl -L raw.github.com/Sakurai00/dotfiles/master/init.sh)"
 
+# 設定
 OS="$(uname)"
+DOTFILES_REPO_URL="${DOTFILES_REPO_URL:-https://github.com/Sakurai00/dotfiles.git}"
+DOTFILES_DIR="${DOTFILES_DIR:-$HOME/dotfiles}"
+DOTFILES_DEFAULT_TAGS="${DOTFILES_DEFAULT_TAGS:-minimum}"
+OS_RELEASE_FILE="${OS_RELEASE_FILE:-/etc/os-release}"
 
-if [ "$OS" == "Darwin" ]; then
-    # macOS setup
-    if ! type brew >/dev/null 2>&1; then
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-        if [ -f /opt/homebrew/bin/brew ]; then
-            eval "$(/opt/homebrew/bin/brew shellenv)"
-        elif [ -f /usr/local/bin/brew ]; then
-            eval "$(/usr/local/bin/brew shellenv)"
-        fi
-    fi
-    if ! type git >/dev/null 2>&1; then
-        brew install git
-    fi
-    if ! type ansible >/dev/null 2>&1; then
-        brew install ansible
-    fi
-elif [ "$OS" == "Linux" ]; then
-    # Linux setup (assuming Debian/Ubuntu)
-    if ! type git >/dev/null 2>&1; then
-        sudo apt update && sudo apt install -y git
+# 共通 helper
+log_info() {
+    printf '[init] %s\n' "$1"
+}
+
+log_warn() {
+    printf '[init] %s\n' "$1" >&2
+}
+
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# ============================================================================
+
+# Linux の判定材料を /etc/os-release から読む。
+read_os_release_value() {
+    local key="$1"
+
+    if [[ ! -f "${OS_RELEASE_FILE}" ]]; then
+        return 1
     fi
 
-    if ! type pip >/dev/null 2>&1; then
-        sudo apt update && sudo apt install -y python3-pip
+    awk -F= -v key="${key}" '$1 == key { gsub(/^"|"$/, "", $2); print $2; exit }' "${OS_RELEASE_FILE}"
+}
+
+# Linux では利用可能な package manager を自動判定する。
+detect_linux_package_manager() {
+    local os_id os_like
+    os_id="$(read_os_release_value ID || true)"
+    os_like="$(read_os_release_value ID_LIKE || true)"
+
+    case " ${os_id} ${os_like} " in
+        *" fedora "*|*" rhel "*|*" rocky "*|*" almalinux "*|*" centos "*)
+            if command_exists dnf; then
+                printf 'dnf\n'
+                return 0
+            fi
+            ;;
+        *" debian "*|*" ubuntu "*)
+            if command_exists apt; then
+                printf 'apt\n'
+                return 0
+            fi
+            ;;
+    esac
+
+    if command_exists apt; then
+        printf 'apt\n'
+        return 0
     fi
 
-    if ! type ansible >/dev/null 2>&1; then
-        pip3 install --user ansible
-        export PATH="$HOME/.local/bin:$PATH"
+    if command_exists dnf; then
+        printf 'dnf\n'
+        return 0
     fi
-else
-    echo "Unsupported OS: $OS"
+
+    log_warn "Unsupported Linux package manager"
     exit 1
+}
+
+# macOS では brew 導入後の shellenv を反映する。
+ensure_homebrew() {
+    if [[ "${OS}" != "Darwin" ]]; then
+        return 0
+    fi
+
+    if command_exists brew; then
+        return 0
+    fi
+
+    log_info "Installing Homebrew"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+    if [[ -f /opt/homebrew/bin/brew ]]; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif [[ -f /usr/local/bin/brew ]]; then
+        eval "$(/usr/local/bin/brew shellenv)"
+    fi
+}
+
+# Linux 依存の install 差分はここに集約する。
+install_linux_packages() {
+    local package_manager
+    package_manager="$(detect_linux_package_manager)"
+
+    case "${package_manager}" in
+        apt)
+            log_info "Installing $* with apt"
+            log_info "Updating apt package index"
+            sudo apt update
+            sudo apt install -y "$@"
+            ;;
+        dnf)
+            log_info "Installing $* with dnf"
+            sudo dnf --refresh install -y "$@"
+            ;;
+        *)
+            log_warn "Unsupported Linux package manager: ${package_manager}"
+            exit 1
+            ;;
+    esac
+}
+
+# pip 経由の Python パッケージ導入をまとめる。
+install_pip_packages() {
+    if ! command_exists pip3; then
+        install_linux_packages python3-pip
+    fi
+    log_info "Installing $* with pip3"
+    pip3 install --user "$@"
+}
+
+# ============================================================================
+
+# git は OS ごとの package manager で導入する。
+ensure_git() {
+    if command_exists git; then
+        return 0
+    fi
+
+    case "${OS}" in
+        Darwin)
+            ensure_homebrew
+            log_info "Installing git with Homebrew"
+            brew install git
+            ;;
+        Linux)
+            install_linux_packages git
+            ;;
+        *)
+            log_warn "Unsupported OS: ${OS}"
+            exit 1
+            ;;
+    esac
+}
+
+# ansible は package manager と pip3 を組み合わせて導入する。
+ensure_ansible() {
+    if command_exists ansible; then
+        return 0
+    fi
+
+    case "${OS}" in
+        Darwin)
+            ensure_homebrew
+            log_info "Installing ansible with Homebrew"
+            brew install ansible
+            ;;
+        Linux)
+            install_pip_packages ansible
+            export PATH="$HOME/.local/bin:$PATH"
+            ;;
+        *)
+            log_warn "Unsupported OS: ${OS}"
+            exit 1
+            ;;
+    esac
+}
+
+# dotfiles checkout の clone/update を担当する。
+sync_repo() {
+    if [[ ! -d "${DOTFILES_DIR}/.git" ]]; then
+        log_info "Cloning dotfiles repository"
+        git clone "${DOTFILES_REPO_URL}" "${DOTFILES_DIR}"
+        cd "${DOTFILES_DIR}"
+        return 0
+    fi
+
+    cd "${DOTFILES_DIR}"
+
+    log_info "Fetching origin/master"
+    git fetch origin master
+
+    if git merge-base --is-ancestor HEAD origin/master; then
+        if [[ "$(git rev-parse HEAD)" == "$(git rev-parse origin/master)" ]]; then
+            log_info "dotfiles is already up to date"
+            return 0
+        fi
+
+        log_info "Fast-forwarding to origin/master"
+        git merge --ff-only origin/master
+        return 0
+    fi
+
+    log_warn "Cannot fast-forward; manual sync required: ${DOTFILES_DIR}"
+}
+
+# playbook 実行は最後にまとめて行う。
+run_playbook() {
+    local tags="${DOTFILES_TAGS:-$DOTFILES_DEFAULT_TAGS}"
+
+    log_info "Running ansible-playbook (tags: ${tags})"
+    ansible-playbook -i ./inventories/production/hosts.yml ./playbook.yml --ask-become-pass --tags "${tags}"
+}
+
+# ============================================================================
+
+# main は bootstrap の大まかな流れだけを残す。
+main() {
+    ensure_git
+    ensure_ansible
+    sync_repo
+    run_playbook
+}
+
+if [[ "${DOTFILES_INIT_TESTING:-0}" != "1" ]]; then
+    main "$@"
 fi
-
-# Clone/Update dotfiles
-if [ ! -d "$HOME/dotfiles" ]; then
-    git clone https://github.com/Sakurai00/dotfiles.git "$HOME/dotfiles"
-    cd "$HOME/dotfiles" || exit
-else
-    cd "$HOME/dotfiles" || exit
-    git pull
-fi
-
-# Determine tags to run
-TAGS="zsh,fzf"
-# Add minimum/normal tags if you want to include other basic roles
-# TAGS="minimum,normal"
-
-ansible-playbook -i ./inventories/production/hosts.yml ./playbook.yml --ask-become-pass --tags "$TAGS"


### PR DESCRIPTION
## 概要
- `init.sh` を関数ベースに整理し、依存導入・repo同期・playbook実行の流れを追いやすくしました
- Linux の前提コマンド導入で `apt` / `dnf` を自動判定できるようにしました
- README の `Components` と `Commands & Key Config` を現在の構成に合わせて更新しました

## 変更内容
- `init.sh`
  - `ensure_git` / `ensure_ansible` / `sync_repo` / `run_playbook` などに責務を分割
  - `git pull` をやめ、`fetch` 後の fast-forward のみで同期するように変更
  - Linux で `apt` / `dnf` を判定して依存導入できるように変更
  - デフォルトの tags を `minimum` に変更
- `README.md`
  - install 導線の説明を更新
  - `Components` を現在のツール構成に合わせて整理
  - shell / git / tmux のショートカット説明を最新化

## 確認したこと
- `bash -n init.sh`

Closes #152