### PR TITLE
common role から全体 upgrade を削除する

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,18 +1,3 @@
----
-
-- name: Upgrade packages (Linux)
-  become: true
-  ansible.builtin.package:
-    name: '*'
-    state: latest
-  when: ansible_facts['system'] == 'Linux'
-
-- name: Upgrade packages (macOS)
-  community.general.homebrew:
-    update_homebrew: true
-    upgrade_all: true
-  when: ansible_facts['system'] == 'Darwin'
-
 - name: Install common packages (Linux)
   become: true
   ansible.builtin.package:


### PR DESCRIPTION
## 概要
- `common` role から Linux/macOS の全体 upgrade タスクを削除
- 通常の dotfiles 適用でシステム全体の更新が走らないように整理
- `common` role の責務を最低限の依存導入に寄せる

## 確認したこと
- `ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_REMOTE_TEMP=/tmp/ansible-remote ansible-playbook --syntax-check playbook.yml`

## 影響
- `common` 実行時に package 全体更新や Homebrew 全体 upgrade は行われなくなる

Closes #178