### PR TITLE
package install roleをdata-drivenに整理

### DIFF
--- a/roles/c/defaults/main.yml
+++ b/roles/c/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+c_package_manager_packages:
+  apt:
+    - build-essential
+    - gdb
+    - clang
+    - lldb
+    - cmake
+  dnf:
+    - '@Development tools'
+    - gdb
+    - clang
+    - lldb
+    - cmake
+  homebrew:
+    - gdb
+    - llvm
+    - cmake

--- a/roles/c/defaults/main.yml
+++ b/roles/c/defaults/main.yml
@@ -6,13 +6,16 @@ c_package_manager_packages:
     - clang
     - lldb
     - cmake
+    - pkg-config
   dnf:
     - '@Development tools'
     - gdb
     - clang
     - lldb
     - cmake
+    - pkgconf-pkg-config
   homebrew:
     - gdb
     - llvm
     - cmake
+    - pkg-config

--- a/roles/c/tasks/main.yml
+++ b/roles/c/tasks/main.yml
@@ -1,22 +1,6 @@
 ---
 
-- name: Install C/C++ packages (Linux)
-  become: true
-  ansible.builtin.package:
-    name:
-      - "{{ 'build-essential' if ansible_pkg_mgr == 'apt' else '@Development tools' }}"
-      - gdb
-      - clang
-      - lldb
-      - cmake
-    state: latest
-  when: ansible_facts['system'] == 'Linux'
-
-- name: Install C/C++ packages (macOS)
-  community.general.homebrew:
-    name:
-      - gdb
-      - llvm
-      - cmake
-    state: latest
-  when: ansible_facts['system'] == 'Darwin'
+- name: Install C/C++ packages
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/install_os_packages.yml"
+  vars:
+    _package_manager_packages: "{{ c_package_manager_packages }}"

--- a/roles/cli_tools/defaults/main.yml
+++ b/roles/cli_tools/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+cli_tools_cargo_packages:
+  - eza
+  - git-delta
+  - bat
+  - ripgrep

--- a/roles/cli_tools/defaults/main.yml
+++ b/roles/cli_tools/defaults/main.yml
@@ -4,3 +4,4 @@ cli_tools_cargo_packages:
   - git-delta
   - bat
   - ripgrep
+  - fd-find

--- a/roles/cli_tools/tasks/main.yml
+++ b/roles/cli_tools/tasks/main.yml
@@ -5,8 +5,4 @@
     name: "{{ item }}"
   environment:
     PATH: "{{ home }}/.cargo/bin:{{ ansible_facts['env']['PATH'] }}"
-  loop:
-    - eza
-    - git-delta
-    - bat
-    - ripgrep
+  loop: "{{ cli_tools_cargo_packages }}"

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -3,17 +3,14 @@ common_package_manager_packages:
   apt:
     - curl
     - wget
-    - git
     - snapd
     - libssl-dev
   dnf:
     - curl
     - wget
-    - git
     - snapd
     - openssl-devel
   homebrew:
     - curl
     - wget
-    - git
     - openssl

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+common_package_manager_packages:
+  apt:
+    - curl
+    - wget
+    - git
+    - snapd
+    - libssl-dev
+  dnf:
+    - curl
+    - wget
+    - git
+    - snapd
+    - openssl-devel
+  homebrew:
+    - curl
+    - wget
+    - git
+    - openssl

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,21 +1,4 @@
-- name: Install common packages (Linux)
-  become: true
-  ansible.builtin.package:
-    name:
-      - curl
-      - wget
-      - git
-      - snapd
-      - "{{ 'libssl-dev' if ansible_pkg_mgr == 'apt' else 'openssl-devel' }}"
-    state: latest
-  when: ansible_facts['system'] == 'Linux'
-
-- name: Install common packages (macOS)
-  community.general.homebrew:
-    name:
-      - curl
-      - wget
-      - git
-      - openssl
-    state: latest
-  when: ansible_facts['system'] == 'Darwin'
+- name: Install common packages
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/install_os_packages.yml"
+  vars:
+    _package_manager_packages: "{{ common_package_manager_packages }}"

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,15 +1,22 @@
 ---
-docker_apt_dependency_packages:
-  - ca-certificates
-  - curl
-  - gnupg
+docker_repository_dependency_packages:
+  apt:
+    - ca-certificates
+    - curl
+    - gnupg
+  dnf:
+    - dnf-plugins-core
 
-docker_dnf_dependency_packages:
-  - dnf-plugins-core
-
-docker_packages:
-  - docker-ce
-  - docker-ce-cli
-  - containerd.io
-  - docker-buildx-plugin
-  - docker-compose-plugin
+docker_package_manager_packages:
+  apt:
+    - docker-ce
+    - docker-ce-cli
+    - containerd.io
+    - docker-buildx-plugin
+    - docker-compose-plugin
+  dnf:
+    - docker-ce
+    - docker-ce-cli
+    - containerd.io
+    - docker-buildx-plugin
+    - docker-compose-plugin

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+docker_apt_dependency_packages:
+  - ca-certificates
+  - curl
+  - gnupg
+
+docker_dnf_dependency_packages:
+  - dnf-plugins-core
+
+docker_packages:
+  - docker-ce
+  - docker-ce-cli
+  - containerd.io
+  - docker-buildx-plugin
+  - docker-compose-plugin

--- a/roles/docker/tasks/install.yml
+++ b/roles/docker/tasks/install.yml
@@ -2,10 +2,7 @@
 - name: Install dependencies for Docker (apt)
   become: true
   ansible.builtin.apt:
-    name:
-      - ca-certificates
-      - curl
-      - gnupg
+    name: "{{ docker_apt_dependency_packages }}"
     state: present
   when: ansible_pkg_mgr == 'apt'
 
@@ -26,7 +23,7 @@
 - name: Install dnf-plugins-core (dnf)
   become: true
   ansible.builtin.dnf:
-    name: dnf-plugins-core
+    name: "{{ docker_dnf_dependency_packages }}"
     state: present
   when: ansible_pkg_mgr == 'dnf'
 
@@ -44,12 +41,7 @@
 - name: Install Docker components
   become: true
   ansible.builtin.package:
-    name:
-      - docker-ce
-      - docker-ce-cli
-      - containerd.io
-      - docker-buildx-plugin
-      - docker-compose-plugin
+    name: "{{ docker_packages }}"
     state: present
     update_cache: true
 

--- a/roles/docker/tasks/install.yml
+++ b/roles/docker/tasks/install.yml
@@ -1,33 +1,28 @@
 ---
-- name: Install dependencies for Docker (apt)
-  become: true
-  ansible.builtin.apt:
-    name: "{{ docker_apt_dependency_packages }}"
-    state: present
-  when: ansible_pkg_mgr == 'apt'
+- name: Docker | repository dependencies
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/install_os_packages.yml"
+  vars:
+    _package_manager_packages: "{{ docker_repository_dependency_packages }}"
+    _package_state: present
 
-- name: Add Docker GPG key (apt)
+- name: Docker | apt gpg key
   become: true
   ansible.builtin.apt_key:
     url: https://download.docker.com/linux/ubuntu/gpg
     state: present
   when: ansible_pkg_mgr == 'apt'
 
-- name: Add Docker repository (apt)
+- name: Docker | apt repository
   become: true
   ansible.builtin.apt_repository:
-    repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+    repo: >-
+      deb [arch=amd64] https://download.docker.com/linux/ubuntu
+      {{ ansible_distribution_release }}
+      stable
     state: present
   when: ansible_pkg_mgr == 'apt'
 
-- name: Install dnf-plugins-core (dnf)
-  become: true
-  ansible.builtin.dnf:
-    name: "{{ docker_dnf_dependency_packages }}"
-    state: present
-  when: ansible_pkg_mgr == 'dnf'
-
-- name: Add Docker repository (dnf)
+- name: Docker | dnf repository
   become: true
   ansible.builtin.command:
     argv:
@@ -38,14 +33,13 @@
     creates: /etc/yum.repos.d/docker-ce.repo
   when: ansible_pkg_mgr == 'dnf'
 
-- name: Install Docker components
-  become: true
-  ansible.builtin.package:
-    name: "{{ docker_packages }}"
-    state: present
-    update_cache: true
+- name: Docker | packages
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/install_os_packages.yml"
+  vars:
+    _package_manager_packages: "{{ docker_package_manager_packages }}"
+    _package_state: present
 
-- name: Ensure Docker service is started and enabled
+- name: Docker | service
   become: true
   ansible.builtin.service:
     name: docker

--- a/roles/fzf/defaults/main.yml
+++ b/roles/fzf/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+fzf_darwin_packages:
+  - fzf

--- a/roles/fzf/tasks/install.yml
+++ b/roles/fzf/tasks/install.yml
@@ -28,8 +28,8 @@
     - ansible_facts['system'] == 'Linux'
     - fzf_repo.changed or not fzf_binary.stat.exists
 
-- name: Install fzf (macOS)
-  community.general.homebrew:
-    name: fzf
-    state: latest
-  when: ansible_facts['system'] == 'Darwin'
+- name: Install fzf package (macOS)
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/install_os_packages.yml"
+  vars:
+    _package_manager_packages:
+      homebrew: "{{ fzf_darwin_packages }}"

--- a/roles/git/defaults/main.yml
+++ b/roles/git/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+git_package_manager_packages:
+  apt:
+    - git
+  dnf:
+    - git
+  homebrew:
+    - git

--- a/roles/git/tasks/install.yml
+++ b/roles/git/tasks/install.yml
@@ -1,16 +1,8 @@
 ---
-- name: Install git (Linux)
-  become: true
-  ansible.builtin.package:
-    name: git
-    state: present
-  when: ansible_facts['system'] == 'Linux'
-
-- name: Install git (macOS)
-  community.general.homebrew:
-    name: git
-    state: latest
-  when: ansible_facts['system'] == 'Darwin'
+- name: Install git packages
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/install_os_packages.yml"
+  vars:
+    _package_manager_packages: "{{ git_package_manager_packages }}"
 
 - name: Install ghq via shared mise helper
   ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/install_mise_tool.yml"

--- a/roles/neovim/defaults/main.yml
+++ b/roles/neovim/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+neovim_package_manager_packages:
+  apt:
+    - neovim
+  dnf:
+    - neovim
+  homebrew:
+    - neovim

--- a/roles/neovim/tasks/install.yml
+++ b/roles/neovim/tasks/install.yml
@@ -1,14 +1,6 @@
 ---
 
-- name: Install neovim (Linux)
-  become: true
-  ansible.builtin.package:
-    name: neovim
-    state: latest
-  when: ansible_facts['system'] == 'Linux'
-
-- name: Install neovim (macOS)
-  community.general.homebrew:
-    name: neovim
-    state: latest
-  when: ansible_facts['system'] == 'Darwin'
+- name: Install neovim packages
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/install_os_packages.yml"
+  vars:
+    _package_manager_packages: "{{ neovim_package_manager_packages }}"

--- a/roles/shared/tasks/install_os_packages.yml
+++ b/roles/shared/tasks/install_os_packages.yml
@@ -1,0 +1,29 @@
+---
+# Required:
+# - _package_manager_packages: package lists keyed by package manager
+# Optional:
+# - _package_state: package state (default "latest")
+
+- name: Resolve package manager package list
+  ansible.builtin.set_fact:
+    _selected_package_manager: "{{ 'homebrew' if ansible_facts['system'] == 'Darwin' else ansible_pkg_mgr }}"
+    _selected_packages: >-
+      {{ _package_manager_packages['homebrew'] if ansible_facts['system'] == 'Darwin'
+         else _package_manager_packages[ansible_pkg_mgr] | default([]) }}
+
+- name: Install packages (Linux)
+  become: true
+  ansible.builtin.package:
+    name: "{{ _selected_packages }}"
+    state: "{{ _package_state | default('latest') }}"
+  when:
+    - ansible_facts['system'] == 'Linux'
+    - (_selected_packages | length) > 0
+
+- name: Install packages (macOS)
+  community.general.homebrew:
+    name: "{{ _selected_packages }}"
+    state: "{{ _package_state | default('latest') }}"
+  when:
+    - ansible_facts['system'] == 'Darwin'
+    - (_selected_packages | length) > 0

--- a/roles/tmux/defaults/main.yml
+++ b/roles/tmux/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+tmux_package_manager_packages:
+  apt:
+    - tmux
+  dnf:
+    - tmux
+  homebrew:
+    - tmux

--- a/roles/tmux/tasks/install.yml
+++ b/roles/tmux/tasks/install.yml
@@ -1,17 +1,9 @@
 ---
 
-- name: Install tmux (Linux)
-  become: true
-  ansible.builtin.package:
-    name: tmux
-    state: latest
-  when: ansible_facts['system'] == 'Linux'
-
-- name: Install tmux (macOS)
-  community.general.homebrew:
-    name: tmux
-    state: latest
-  when: ansible_facts['system'] == 'Darwin'
+- name: Install tmux packages
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/install_os_packages.yml"
+  vars:
+    _package_manager_packages: "{{ tmux_package_manager_packages }}"
 
 - name: Clone tpm
   ansible.builtin.git:

--- a/roles/vim/defaults/main.yml
+++ b/roles/vim/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+vim_package_manager_packages:
+  apt:
+    - vim
+  dnf:
+    - vim
+  homebrew:
+    - vim

--- a/roles/vim/tasks/install.yml
+++ b/roles/vim/tasks/install.yml
@@ -1,14 +1,6 @@
 ---
 
-- name: Install vim (Linux)
-  become: true
-  ansible.builtin.package:
-    name: vim
-    state: latest
-  when: ansible_facts['system'] == 'Linux'
-
-- name: Install vim (macOS)
-  community.general.homebrew:
-    name: vim
-    state: latest
-  when: ansible_facts['system'] == 'Darwin'
+- name: Install vim packages
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/install_os_packages.yml"
+  vars:
+    _package_manager_packages: "{{ vim_package_manager_packages }}"

--- a/roles/zsh/defaults/main.yml
+++ b/roles/zsh/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+zsh_package_manager_packages:
+  apt:
+    - zsh
+  dnf:
+    - zsh
+  homebrew:
+    - zsh

--- a/roles/zsh/tasks/install.yml
+++ b/roles/zsh/tasks/install.yml
@@ -1,14 +1,6 @@
 ---
 
-- name: Install zsh (Linux)
-  become: true
-  ansible.builtin.package:
-    name: zsh
-    state: latest
-  when: ansible_facts['system'] == 'Linux'
-
-- name: Install zsh (macOS)
-  community.general.homebrew:
-    name: zsh
-    state: latest
-  when: ansible_facts['system'] == 'Darwin'
+- name: Install zsh packages
+  ansible.builtin.import_tasks: "{{ playbook_dir }}/roles/shared/tasks/install_os_packages.yml"
+  vars:
+    _package_manager_packages: "{{ zsh_package_manager_packages }}"


### PR DESCRIPTION
## 概要
- 単純な package install role を data-driven に整理
- cli_tools の cargo package 定義を defaults 側へ移動
- docker role の install 処理を 1 ファイル構成のまま整理

## 変更内容
- shared の package install task を追加し、package manager ごとの package 定義を role の defaults 側へ寄せた
- common / c / git / zsh / vim / neovim / tmux / fzf / docker の install 定義を整理した
- cli_tools の cargo package 一覧を defaults に移し、fd-find を追加した
- docker role は package install を shared task に寄せつつ、repository 追加と service 管理の責務が読みやすい形に整えた

## 確認したこと
- `ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_REMOTE_TEMP=/tmp/ansible-remote ansible-playbook -i inventories/production/hosts.yml playbook.yml --syntax-check`

## 補足
- `roles/git/files/.gitconfig.local` の既存ローカル変更はこの PR に含めていません

Closes #172
Closes #173
Closes #186
