### PR TITLE
[codex] fzf の zsh 初期化を一本化する

### DIFF
--- a/roles/fzf/files/.zsh/conf.d/fzf.zsh
+++ b/roles/fzf/files/.zsh/conf.d/fzf.zsh
@@ -1,38 +1,15 @@
 # fzf installation root search
 # ---------------------------
-_fzf_candidates=(
-    "$HOME/.fzf"            # Linux (git installation)
-    "/opt/homebrew/opt/fzf" # macOS (Homebrew Apple Silicon)
-    "/usr/local/opt/fzf"    # macOS (Homebrew Intel)
-)
-
-_fzf_root=""
-for _dir in $_fzf_candidates; do
-    if [[ -d "$_dir" ]]; then
-        _fzf_root="$_dir"
-        break
-    fi
-done
-
-# Environment Setup
-# -----------------
-if [[ -n "$_fzf_root" ]]; then
-    # Add to PATH if it's a manual git install
-    [[ "$_fzf_root" == "$HOME/.fzf" ]] && path=("$_fzf_root/bin" $path)
-
-    # Auto-completion
-    [[ $- == *i* ]] && source "$_fzf_root/shell/completion.zsh" 2> /dev/null
-
-    # Key bindings
-    source "$_fzf_root/shell/key-bindings.zsh"
+# Keep PATH setup only for the Linux git-clone install. Shell integration
+# itself is sourced from the fzf binary below.
+if [[ -d "$HOME/.fzf/bin" ]]; then
+    path=("$HOME/.fzf/bin" $path)
 fi
 
 # Modern Initialization (fzf >= 0.48.0)
 if type fzf > /dev/null 2>&1; then
     source <(fzf --zsh)
 fi
-
-unset _fzf_candidates _fzf_root
 
 export FZF_COMPLETION_TRIGGER=','
 


### PR DESCRIPTION
## 概要
- `roles/fzf/files/.zsh/conf.d/fzf.zsh` の初期化経路を `source <(fzf --zsh)` に一本化
- legacy な `completion.zsh` / `key-bindings.zsh` の直接読み込みを削除
- Linux の `~/.fzf` git clone 版だけ `PATH` 追加を残す形に整理

## 変更理由
- `fzf` の zsh 初期化が legacy 手動読み込みと modern initialization の併用になっており、責務が分散していたため
- 公式ドキュメントの推奨に合わせて、初期化フローを 1 つに揃えたかったため

## 確認したこと
- `zsh -n roles/fzf/files/.zsh/conf.d/fzf.zsh`
- `ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_REMOTE_TEMP=/tmp/ansible-remote ansible-playbook -i inventories/production/hosts.yml playbook.yml --syntax-check`

## 影響範囲
- `fzf` の zsh shell integration 読み込み経路
- `~/.fzf` を使う Linux 環境での `PATH` 追加処理

Closes #151